### PR TITLE
Issues 5 & 6

### DIFF
--- a/protopipe/pipeline/event_preparer.py
+++ b/protopipe/pipeline/event_preparer.py
@@ -386,10 +386,10 @@ class EventPreparer:
                     try:
 
                         moments_reco = hillas_parameters(
-                            camera, image_biggest
+                            camera_biggest, image_biggest
                         )  # for geometry (eg direction)
                         moments = hillas_parameters(
-                            camera, image_extended
+                            camera_extended, image_extended
                         )  # for discrimination and energy reconstruction
 
                         # if width and/or length are zero (e.g. when there is

--- a/protopipe/pipeline/image_cleaning.py
+++ b/protopipe/pipeline/image_cleaning.py
@@ -108,6 +108,8 @@ class ImageCleaner(object):
         -------
         new_img: `np.array`
             Cleaned image
+        mask: `np.array`
+            Boolean array which corresponds to the cleaned pixels
         """
 
         new_img = np.copy(img)
@@ -116,12 +118,15 @@ class ImageCleaner(object):
         if self.mode in "tail":
             mask = self.cleaners[cam_id](new_img, geom, self.clean_opts[cam_id])
             new_img[~mask] = 0
+            # this is still the full camera, but the non-surviving pixels are
+            # set to 0: this is not a problem for the number_of_islands
+            # ctapipe function used later
 
-            return new_img
+            return new_img, mask
 
         if self.mode in "wave":
             image_2d = geometry_converter.image_1d_to_2d(new_img, cam_id)
             image_2d = self.cleaners[cam_id](image_2d, self.clean_opts[cam_id])
             new_img = geometry_converter.image_2d_to_1d(image_2d, cam_id)
 
-        return new_img
+        return new_img, mask


### PR DESCRIPTION
In **event_preparer.py**

- there is code from PR on ctapipe that allows largest cluster selection, but that is not present in conda ctapipe 0.7
-  tailcut and wavelet cleaning algorithms are now definitely separated
- in the case of tailcut (for the moment the most used option) Hillas parametrization is done on the filtered camera geometry and DL1 image for improved speed

In **image_cleaning.py**,

- method "clean_image" now gives back also the mask, together with the cleaned full camera image.