### PR TITLE
Patch update install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,18 @@ Get the source code and create the required basic conda environment:
           conda env create -f protopipe_environment.yml
           conda activate protopipe
 
-This environment (named _protopipe_) contains the bare minimum in order to run the scripts and build the documentation.
+This environment contains the bare minimum in order to run the scripts and build the documentation.
 
 It doesn't take into account any additional tool you could use later on (it is suggested to install _ipython_, _jupyter_ and _vitables_, especially if you want to contribute to the code).
 
-For the moment, a module named _pywi-cta_ has to be installed:
-
-          cd ../
-          git clone https://github.com/HealthyPear/pywi-cta.git
-          cd pywi-cta
-          python setup.py install
-
-Finally, you need to install _protopipe_ itself:
+Next you need to install _protopipe_ itself:
 
           cd protopipe
           python setup.py develop
 
 This will let you make changes to your local git repository without the need to update your environment every time.
 
+Remember that the environment needs to be activated in order for _protopipe_ to work.
 This procedure has been successfully tested on macOS (10.10.5 & 10.14.6) and on Scientific Linux 7.
 
 Building the documentation:

--- a/README.md
+++ b/README.md
@@ -53,33 +53,33 @@ Before starting to use protopipe, be sure to be inside the environment you creat
 
 Then, a typical workflow consists in:
 
-  1. create an analysis parent folder with the auxiliary script create_dir_structure.py
-  2. prepare the configuration files
-    1. copy the example YAML configuration files in the relative subfolders
-    2. edit them for the particular needs of your analysis
-  3. build a model for energy estimation
-    1. Create tables for gamma-rays using write_dl1.py and analysis.yaml
-    2. Merge them with the auxiliary script merge.sh
-    3. create the model with build_model.py and regressor.yaml
-    4. check it's performance with model_diagnostic.py and regressor.yaml
-  4. build a model for gamma/hadron separation
-    1. set 'estimate_energy' to True when using write_dl1.py so the reconstructed energy can be estimated and further used as a discriminant parameter.
-    2. same process as for the energy estimation but using classifier.yaml
-  5. produce DL2-level data
-    1. create tables for gamma-rays, protons and electrons using write_dl2.py and analysis.yaml
-    2. merge them with the auxiliary script merge.sh
-  6. Estimate the final performance (IRFs) with make_performance.py and performance.yaml
+1. create an analysis parent folder with the auxiliary script create_dir_structure.py
+2. prepare the configuration files
+  1. copy the example YAML configuration files in the relative subfolders
+  2. edit them for the particular needs of your analysis
+3. build a model for energy estimation
+  1. Create tables for gamma-rays using write_dl1.py and analysis.yaml
+  2. Merge them with the auxiliary script merge.sh
+  3. create the model with build_model.py and regressor.yaml
+  4. check it's performance with model_diagnostic.py and regressor.yaml
+4. build a model for gamma/hadron separation
+  1. set 'estimate_energy' to True when using write_dl1.py so the reconstructed energy can be estimated and further used as a discriminant parameter.
+  2. same process as for the energy estimation but using classifier.yaml
+5. produce DL2-level data
+  1. create tables for gamma-rays, protons and electrons using write_dl2.py and analysis.yaml
+  2. merge them with the auxiliary script merge.sh
+6. Estimate the final performance (IRFs) with make_performance.py and performance.yaml
 
 Instructions for developers:
 ----------------------------
 
-  1. Fork the master _protopipe_ remote repository as explained [here](https://help.github.com/en/articles/fork-a-repo)
-  2. Follow the installation instructions above, but using __your__ remote repository (we'll call __origin__ yours and __upstream__ the official one)
-  3. if you want to develop something new:
-    1. create a new branch from your __local__ _master_ branch
-    2. develop inside it
-    3. push it to __origin__
-    4. continue to develop and push until you feel ready
-  4. start a __pull request__ from __origin/your_branch__ to __upstream/master__
-    1. wait for an outcome
-    2. if necessary, you can update or fix things in your branch because now everything is traced (__local/your_branch__ --> __origin/your_branch__ --> __pull request__)
+1. Fork the master _protopipe_ remote repository as explained [here](https://help.github.com/en/articles/fork-a-repo)
+2. Follow the installation instructions above, but using __your__ remote repository (we'll call __origin__ yours and __upstream__ the official one)
+3. if you want to develop something new:
+  1. create a new branch from your __local__ _master_ branch
+  2. develop inside it
+  3. push it to __origin__
+  4. continue to develop and push until you feel ready
+4. start a __pull request__ from __origin/your_branch__ to __upstream/master__
+  1. wait for an outcome
+  2. if necessary, you can update or fix things in your branch because now everything is traced (__local/your_branch__ --> __origin/your_branch__ --> __pull request__)

--- a/protopipe/pipeline/event_preparer.py
+++ b/protopipe/pipeline/event_preparer.py
@@ -331,6 +331,9 @@ class EventPreparer:
                     camera_extended = camera[mask_extended]
                     image_extended = image_extended[mask_extended]
 
+                    # could this go into `hillas_parameters` ...?
+                    max_signals[tel_id] = np.max(image_extended)
+
                 else:  # for wavelets we stick to old pywi-cta code
                     try:  # "try except FileNotFoundError" not clear to me, but for now it stays...
                         with warnings.catch_warnings():

--- a/protopipe_environment.yml
+++ b/protopipe_environment.yml
@@ -1,22 +1,22 @@
 name: protopipe
 channels:
-  - defaults
   - conda-forge
   - cta-observatory
+  - defaults
 dependencies:
   - alabaster=0.7.12
-  - asn1crypto=0.24.0
-  - astropy=3.2.1
+  - asn1crypto=1.2.0
+  - astropy=3.2.2
   - atomicwrites=1.3.0
-  - attrs=19.1.0
+  - attrs=19.2.0
   - babel=2.7.0
   - blas=1.0
   - blosc=1.16.3
   - bokeh=1.3.4
   - bzip2=1.0.8
-  - ca-certificates=2019.8.28
+  - ca-certificates=2019.9.11
   - certifi=2019.9.11
-  - cffi=1.12.3
+  - cffi=1.13.0
   - chardet=3.0.4
   - click=7.0
   - corsikaio=0.2.0
@@ -36,7 +36,7 @@ dependencies:
   - importlib_metadata=0.23
   - intel-openmp=2019.4
   - ipython_genutils=0.2.0
-  - jinja2=2.10.1
+  - jinja2=2.10.3
   - joblib=0.13.2
   - jpeg=9b
   - kiwisolver=1.1.0
@@ -61,22 +61,21 @@ dependencies:
   - numpy=1.17.2
   - numpy-base=1.17.2
   - olefile=0.46
-  - openssl=1.1.1d
+  - openssl=1.1.1c
   - packaging=19.2
   - pandas=0.25.1
-  - pillow=6.1.0
+  - pillow=6.2.0
   - pip=19.2.3
   - pluggy=0.13.0
   - psutil=5.6.3
   - py=1.8.0
   - pycparser=2.19
   - pygments=2.4.2
-  - pyhessio=2.1.1
   - pyopenssl=19.0.0
   - pyparsing=2.4.2
   - pysocks=1.7.1
   - pytables=3.5.2
-  - pytest=5.2.0
+  - pytest=5.2.1
   - pytest-arraydiff=0.3
   - pytest-astropy=0.5.0
   - pytest-doctestplus=0.4.0
@@ -84,17 +83,17 @@ dependencies:
   - pytest-remotedata=0.3.2
   - python=3.7.4
   - python-dateutil=2.8.0
-  - pytz=2019.2
+  - pytz=2019.3
   - pyyaml=5.1.2
   - readline=7.0
   - regions=0.4
   - requests=2.22.0
   - scikit-learn=0.21.3
   - scipy=1.3.1
-  - setuptools=41.2.0
+  - setuptools=41.4.0
   - six=1.12.0
   - snappy=1.1.7
-  - snowballstemmer=1.9.1
+  - snowballstemmer=2.0.0
   - sphinx=2.2.0
   - sphinx-automodapi=0.12
   - sphinx_rtd_theme=0.4.3
@@ -105,12 +104,12 @@ dependencies:
   - sphinxcontrib-qthelp=1.0.2
   - sphinxcontrib-serializinghtml=1.1.3
   - sqlite=3.30.0
-  - tbb=2019.4
+  - tbb=2019.8
   - tk=8.6.8
   - tornado=6.0.3
   - tqdm=4.36.1
-  - traitlets=4.3.2
-  - urllib3=1.24.2
+  - traitlets=4.3.3
+  - urllib3=1.25.6
   - wcwidth=0.1.7
   - wheel=0.33.6
   - xz=5.2.4
@@ -118,9 +117,3 @@ dependencies:
   - zipp=0.6.0
   - zlib=1.2.11
   - zstd=1.3.7
-  - pip:
-    - imageio==2.6.0
-    - networkx==2.3
-    - pywavelets==1.0.3
-    - pywi==0.3.dev12
-    - scikit-image==0.15.0


### PR DESCRIPTION
This pull request updates the installation resources and instructions with the latest changes that made _pywi_ and _pywi-cta_ completely optional.

It adds also a missing variable when building the DL1 table in _tail_ mode.

It should be noted that at the moment _protopipe_ will always print if _pywi-cta_ is missing, thus making wavelets cleaning unavailable.
This could be confusing for some users; perhaps we can fix this in a better way later on.

I thus suggest that this version could be already tagged 0.2.