### PR TITLE
Closes #45

### DIFF
--- a/protopipe/pipeline/event_preparer.py
+++ b/protopipe/pipeline/event_preparer.py
@@ -440,7 +440,7 @@ class EventPreparer:
                         camera_biggest = camera[mask_reco]
                         image_biggest = image_biggest[mask_reco]
                         if save_images is True:
-                        	dl1_phe_image_mask_reco[tel_id] = 1*mask_reco
+                        	dl1_phe_image_mask_reco[tel_id] = mask_reco
                    
                     elif num_islands > 1:  # if more islands survived..
                         # ...find the biggest one
@@ -449,7 +449,7 @@ class EventPreparer:
                         camera_biggest = camera[mask_biggest]
                         image_biggest = image_biggest[mask_biggest]
                         if save_images is True:
-                        	dl1_phe_image_mask_reco[tel_id] = 1*mask_biggest
+                        	dl1_phe_image_mask_reco[tel_id] = mask_biggest
                         	
                     else:  # if no islands survived use old camera and image
                         camera_biggest = camera

--- a/protopipe/scripts/write_dl1.py
+++ b/protopipe/scripts/write_dl1.py
@@ -110,9 +110,10 @@ def main():
     class StoredImages(tb.IsDescription):
         event_id = tb.Int32Col(dflt=1, pos=0)
         tel_id = tb.Int16Col(dflt=1, pos=1)
-        dl1_phe_image = tb.Float32Col(shape=(1855), pos=2)
-        mc_phe_image = tb.Float32Col(shape=(1855), pos=3)
-        mc_energy = tb.Float32Col(dflt=1, pos=4)
+        dl1_phe_image=tb.Float32Col(shape=(1855), pos=2)
+        dl1_phe_image_mask_reco=tb.Float32Col(shape=(1855), pos=3)
+        mc_phe_image = tb.Float32Col(shape=(1855), pos=4)
+        mc_energy = tb.Float32Col(dflt=1, pos=5)
 
     # Declaration of the column descriptor for the file containing DL1 data
     class EventFeatures(tb.IsDescription):
@@ -186,6 +187,7 @@ def main():
         for (
             event,
             dl1_phe_image,
+            dl1_phe_image_mask_reco,
             mc_phe_image,
             n_pixel_dict,
             hillas_dict,
@@ -347,8 +349,9 @@ def main():
                 if args.save_images is True:
                     images_phe[cam_id]["event_id"] = event.r0.event_id
                     images_phe[cam_id]["tel_id"] = tel_id
-                    images_phe[cam_id]["dl1_phe_image"] = dl1_phe_image
-                    images_phe[cam_id]["mc_phe_image"] = mc_phe_image
+                    images_phe[cam_id]["dl1_phe_image"] = dl1_phe_image[tel_id] 
+                    images_phe[cam_id]["dl1_phe_image_mask_reco"] = dl1_phe_image_mask_reco[tel_id] 
+                    images_phe[cam_id]["mc_phe_image"] = mc_phe_image[tel_id]
                     images_phe[cam_id]["mc_energy"] = event.mc.energy.value  # TeV
 
                     images_phe[cam_id].append()

--- a/protopipe/scripts/write_dl1.py
+++ b/protopipe/scripts/write_dl1.py
@@ -111,7 +111,7 @@ def main():
         event_id = tb.Int32Col(dflt=1, pos=0)
         tel_id = tb.Int16Col(dflt=1, pos=1)
         dl1_phe_image=tb.Float32Col(shape=(1855), pos=2)
-        dl1_phe_image_mask_reco=tb.Float32Col(shape=(1855), pos=3)
+        dl1_phe_image_mask_reco=tb.BoolCol(shape=(1855), pos=3)
         mc_phe_image = tb.Float32Col(shape=(1855), pos=4)
         mc_energy = tb.Float32Col(dflt=1, pos=5)
 


### PR DESCRIPTION
The problem with DL1 images (see #45 ) is fixed.
I add the possibility to save the cleaning mask used for direction's reconstruction.