### PR TITLE
Double-pass image extractor

### DIFF
--- a/protopipe/pipeline/event_preparer.py
+++ b/protopipe/pipeline/event_preparer.py
@@ -364,6 +364,15 @@ class MyCameraCalibrator(CameraCalibrator):
             #   - Update on SST review decision
             corrected_charge = waveforms[..., 0]
             pulse_time = np.zeros(n_pixels)
+
+            # TwoPassWindowSum doesn't have sense in this case, for the moment
+            # I will leave things as they are and return empty containers
+            charge1 = corrected_charge
+            pulse_time1 = pulse_time
+            status = np.nan
+
+            # In the future, each camera ID should have a dedicated and
+            # optimized choice of image extractor
         else:
             # TODO: pass camera to ImageExtractor.__init__
             if self.image_extractor.requires_neighbors():
@@ -399,6 +408,7 @@ class MyCameraCalibrator(CameraCalibrator):
 
         event.dl1.tel[telid].image = corrected_charge
         event.dl1.tel[telid].pulse_time = pulse_time
+
         return charge1, pulse_time1, status
 
     def __call__(self, event):

--- a/protopipe/pipeline/event_preparer.py
+++ b/protopipe/pipeline/event_preparer.py
@@ -2,6 +2,13 @@
 from abc import abstractmethod
 import math
 import numpy as np
+
+# remove with ctapipe0.8
+from scipy.sparse.csgraph import connected_components
+
+# remove with ctapipe0.8
+from numpy.polynomial.polynomial import polyval
+
 from scipy.stats import siegelslopes
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -10,14 +17,11 @@ from traitlets.config import Config
 from collections import namedtuple, OrderedDict
 
 # CTAPIPE utilities
-from ctapipe.io.containers import (
-    ReconstructedShowerContainer,
-    HillasParametersContainer,
-    TimingParametersContainer,
-)
+from ctapipe.io.containers import TimingParametersContainer
 from ctapipe.calib import CameraCalibrator
 from ctapipe.calib.camera.gainselection import GainSelector
-from ctapipe.image.extractor import LocalPeakWindowSum
+
+# from ctapipe.image.extractor import LocalPeakWindowSum
 from ctapipe.image import hillas
 from ctapipe.image.cleaning import tailcuts_clean
 from ctapipe.utils.CutFlow import CutFlow
@@ -28,7 +32,7 @@ from ctapipe.image.extractor import (
     extract_pulse_time_around_peak,
 )
 
-from ctapipe.image.timing_parameters import timing_parameters
+# from ctapipe.image.timing_parameters import timing_parameters
 from ctapipe.image.hillas import hillas_parameters, camera_to_shower_coordinates
 from ctapipe.reco.HillasReconstructor import HillasReconstructor
 

--- a/protopipe/pipeline/utils.py
+++ b/protopipe/pipeline/utils.py
@@ -173,7 +173,7 @@ def final_array_to_use(sim_array, array, subarrays=None):
         tel_types[i].camera.cam_id: tel_types[i].optics.equivalent_focal_length.value
         for i in range(len(tel_types))
     }
-    return set(tel_ids), cams_and_foclens
+    return set(tel_ids), cams_and_foclens, subarray  # redundant, to improve!
 
 
 def prod3b_array(fileName, site, array):

--- a/protopipe/scripts/write_dl1.py
+++ b/protopipe/scripts/write_dl1.py
@@ -68,7 +68,9 @@ def main():
 
     # Get the IDs of the involved telescopes and associated cameras together
     # with the equivalent focal lengths from the first event
-    allowed_tels, cams_and_foclens = prod3b_array(filenamelist[0], site, array)
+    allowed_tels, cams_and_foclens, subarray = prod3b_array(
+        filenamelist[0], site, array
+    )
 
     # keeping track of events and where they were rejected
     evt_cutflow = CutFlow("EventCutFlow")
@@ -76,6 +78,7 @@ def main():
 
     preper = EventPreparer(
         config=cfg,
+        subarray=subarray,
         cams_and_foclens=cams_and_foclens,
         mode=args.mode,
         event_cutflow=evt_cutflow,

--- a/protopipe/scripts/write_dl1.py
+++ b/protopipe/scripts/write_dl1.py
@@ -114,8 +114,10 @@ def main():
         event_id = tb.Int32Col(dflt=1, pos=0)
         tel_id = tb.Int16Col(dflt=1, pos=1)
         dl1_phe_image = tb.Float32Col(shape=(1855), pos=2)
-        mc_phe_image = tb.Float32Col(shape=(1855), pos=3)
-        mc_energy = tb.Float32Col(dflt=1, pos=4)
+        dl1_phe_image_1stPass = tb.Float32Col(shape=(1855), pos=3)
+        calibration_status = tb.Int16Col(dflt=1, pos=4)
+        mc_phe_image = tb.Float32Col(shape=(1855), pos=5)
+        mc_energy = tb.Float32Col(dflt=1, pos=6)
 
     # Declaration of the column descriptor for the file containing DL1 data
     class EventFeatures(tb.IsDescription):
@@ -189,6 +191,8 @@ def main():
         for (
             event,
             dl1_phe_image,
+            dl1_phe_image_1stPass,
+            calibration_status,
             mc_phe_image,
             n_pixel_dict,
             hillas_dict,
@@ -350,8 +354,14 @@ def main():
                 if args.save_images is True:
                     images_phe[cam_id]["event_id"] = event.r0.event_id
                     images_phe[cam_id]["tel_id"] = tel_id
-                    images_phe[cam_id]["dl1_phe_image"] = dl1_phe_image
-                    images_phe[cam_id]["mc_phe_image"] = mc_phe_image
+                    images_phe[cam_id]["dl1_phe_image"] = dl1_phe_image[tel_id]
+                    images_phe[cam_id]["dl1_phe_image_1stPass"] = dl1_phe_image_1stPass[
+                        tel_id
+                    ]
+                    images_phe[cam_id]["calibration_status"] = calibration_status[
+                        tel_id
+                    ]
+                    images_phe[cam_id]["mc_phe_image"] = mc_phe_image[tel_id]
                     images_phe[cam_id]["mc_energy"] = event.mc.energy.value  # TeV
 
                     images_phe[cam_id].append()


### PR DESCRIPTION
**Description:**

This feature is relevant for issues #24, and in particular for issues #31 and #37 .
It has been already pushed to ctapipe (see cta-observatory/ctapipe#1215 for details).
This version complies with the conda-packaged version of ctapipe 0.7, so expect some (not performance-related) differences.

**Caveats:**
- during the tests for the comparison against _CTA-MARS_ it has been necessary to hamper heavily with the code of _ctapipe_; for this reason a lot of classes and their methods needed to be overwritten
- also during said tests it was necessary to use all single-telescope images, feature which required to modify heavily the code of _protopipe_. These changes will be overwritten by the new DL1 writer, and they could also disrupt too much the next steps of the pipeline - for this reason I preferred to keep it simple and leave that part as original as possible. _Protopipe_ will use this image extractor, but the (optionally) exported images will be only those which survive AND contribute to direction reconstruction
- together with the usual DL1 charge and pulse-times (for both passes!), this image extractor exports also a variable called `calibration_status` (only for the optional `images.h5` file); such variable records if an image doesn't survive the 1st pass OR survives it but the image-width from the fit between the 2 passes is NaN; for the previous point, this is of course useless now (since only good images are exported), but I decided to keep it here if we decide to implement this functionality later on.