### PR TITLE
Rollback for GRID support

### DIFF
--- a/protopipe/aux/example_config_files/grid/grid.yaml
+++ b/protopipe/aux/example_config_files/grid/grid.yaml
@@ -52,6 +52,8 @@ GRID:
 # The following DL0 paths refer to directory structure shown at Lugano
 # you will find it together with the rest of the files
 
+# Better use absolute paths to be sure!
+
 EnergyRegressor:
  # This list is used to build an energy regressor, if output_type=DL1 and
  # if estimate_energy is False

--- a/protopipe/aux/example_config_files/protopipe/analysis.yaml
+++ b/protopipe/aux/example_config_files/protopipe/analysis.yaml
@@ -9,6 +9,7 @@ General:
  # WARNING: for simulations containing multiple copies of the telescopes,
  # only 'full_array' or custom list are supported options!
  array: full_array
+ cam_id_list : ['LSTCam'] # List of camera IDs to be used
 
 # Cleaning for reconstruction
 ImageCleaning:

--- a/protopipe/pipeline/utils.py
+++ b/protopipe/pipeline/utils.py
@@ -100,6 +100,14 @@ def make_argparser():
     )
 
     parser.add_argument(
+        "--cam_ids",
+        type=str,
+        default=["LSTCam", "NectarCam"],
+        nargs="*",
+        help="give the specific list of camera types to run on",
+    )
+
+    parser.add_argument(
         "--wave_dir",
         type=str,
         default=None,

--- a/protopipe/scripts/write_dl1.py
+++ b/protopipe/scripts/write_dl1.py
@@ -32,7 +32,7 @@ def main():
     )
 
     parser.add_argument(
-        "--estimate_energy", action="store_true", help="Estimate energy"
+        "--estimate_energy", type=str2bool, default=False, help="Estimate energy"
     )
     parser.add_argument(
         "--regressor_dir", type=str, default="./", help="regressors directory"


### PR DESCRIPTION
When I added `protopipe.pipeline.utils.prod3b_array` I made some changes that influenced the grid interface code.
Since at the time the GRID support was put on hold, I didn't even think that it could be a problem.
Indeed since the 2 repos are _de facto_ separated, there was no automatic test to catch this...

The following changes have been rolled back now:
- removed the camera ID list argument in the general analysis configuration file because that function guesses the properties of the Prod3b array used automatically.
I added back that argument the **must** be filled by the user.
One can put also all the cameras, since `protopipe.pipeline.utils.prod3b_array` will take care of it anyway (making that argument a dummy one).
- same thing for the command line argument in `write_dl1.py`,
- energy estimation command line argument was set to boolean, now it's again a string (this I don't know why was changed actually)

**Other changes:**
I also added a comment about using absolute paths when defining the simtel files lists to be used.
This is useful since I plan to enable the use of a container and the paths could be different from my personal setup.

**Note:** we should check if something like `protopipe.pipeline.utils.prod3b_array` already exists in ctapipe for Prod3b, otherwise it would be wise to add it, at least for Prod5 (issue to be opened soon to be sure).