### PR TITLE
Prepare first upload to PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@
 __pycache__
 
 # ignore version cache file (generated automatically when setup.py is run)
-ctapipe/_version_cache.py
+protopipe/_version_cache.py
+protopipe/_version.py
 
 # Ignore .c files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, use `git add -f filename.c`.

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,4 @@
 {
-  "metadata":  {
     "title" : "protopipe",
     "description": "Pipeline prototype for the Cherenkov Telescope Array (CTA).",
     "license":  {
@@ -68,4 +67,3 @@
         }
       ]
   }
-}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,11 +1,11 @@
 {
   "metadata":  {
     "title" : "protopipe",
-    "description": "A ctapipe-based pipeline prototype for the Cherenkov Telescope Array (CTA).",
+    "description": "Pipeline prototype for the Cherenkov Telescope Array (CTA).",
     "license":  {
       "id": "CECILL-B"
     },
-    "version": "v0.4.0",
+    "doi": "10.5281/zenodo.4303995",
     "keywords": [
       "gamma-ray astronomy",
       "Imaging Atmospheric Cherenkov Telescope",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -65,5 +65,5 @@
           "type": "Other",
           "name": "Garcia, Enrique"
         }
-      ]
+    ]
   }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,7 +4,6 @@
     "license":  {
       "id": "CECILL-B"
     },
-    "doi": "10.5281/zenodo.4303995",
     "keywords": [
       "gamma-ray astronomy",
       "Imaging Atmospheric Cherenkov Telescope",
@@ -29,24 +28,14 @@
           "name": "Lefaucheur, Julien"
         },
         {
-          "affiliation": "AIM, CEA, CNRS, Universite Paris-Saclay, Universite Paris Diderot, Sorbonne Paris Cite, F-91191 Gif-sur-Yvette, France",
-          "type": "Other",
-          "name": "Stolarczyk, Thierry"
-        },
-        {
-          "affiliation": "AIM, CEA, CNRS, Universite Paris-Saclay, Universite Paris Diderot, Sorbonne Paris Cite, F-91191 Gif-sur-Yvette, France",
-          "type": "Other",
-          "name": "Kosack, Karl"
-        },
-        {
           "affiliation": "Aix Marseille Univ, CNRS/IN2P3, CPPM, Marseille, France",
           "type": "Other",
           "name": "Verna, Gaia"
         },
         {
-          "affiliation": "Universit\u00e0 di Udine & INFN Trieste",
+          "affiliation": "AIM, CEA, CNRS, Universite Paris-Saclay, Universite Paris Diderot, Sorbonne Paris Cite, F-91191 Gif-sur-Yvette, France",
           "type": "Other",
-          "name": "Donini, Alice"
+          "name": "Stolarczyk, Thierry"
         },
         {
           "orcid": "0000-0002-5686-2078",
@@ -57,13 +46,23 @@
         {
           "affiliation": "AIM, CEA, CNRS, Universite Paris-Saclay, Universite Paris Diderot, Sorbonne Paris Cite, F-91191 Gif-sur-Yvette, France",
           "type": "Other",
-          "name": "Landriu, David"
+          "name": "Kosack, Karl"
+        },
+        {
+          "affiliation": "Universit\u00e0 di Udine & INFN Trieste",
+          "type": "Other",
+          "name": "Donini, Alice"
         },
         {
           "orcid": "0000-0003-2224-4594",
           "affiliation": "Laboratoire d'Annecy de Physique des Particules, Univ. Grenoble Alpes, Univ. Savoie Mont Blanc, CNRS, LAPP, 74000 Annecy, France",
           "type": "Other",
           "name": "Garcia, Enrique"
+        },
+        {
+          "affiliation": "AIM, CEA, CNRS, Universite Paris-Saclay, Universite Paris Diderot, Sorbonne Paris Cite, F-91191 Gif-sur-Yvette, France",
+          "type": "Other",
+          "name": "Landriu, David"
         }
     ]
   }

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==================================================
-protopipe |CI| |codacy| |coverage| |documentation|
-==================================================
+==============================================================
+protopipe |CI| |codacy| |coverage| |documentation| |doilatest|
+==============================================================
 
 .. |CI| image:: https://github.com/cta-observatory/protopipe/workflows/CI/badge.svg?branch=master
   :target: https://github.com/cta-observatory/protopipe/actions?query=workflow%3ACI
@@ -10,7 +10,9 @@ protopipe |CI| |codacy| |coverage| |documentation|
   :target: https://codecov.io/gh/cta-observatory/protopipe
 .. |documentation| image:: https://readthedocs.org/projects/protopipe/badge/?version=latest
   :target: https://protopipe.readthedocs.io/en/latest/?badge=latest
-.. |doilatest| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4303996.svg
+.. |doilatest| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4303995.svg
+  :target: https://doi.org/10.5281/zenodo.4303995
+.. |doi_v0.3.0| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4303996.svg
   :target: https://doi.org/10.5281/zenodo.4303996
 
 A pipeline prototype for the `Cherenkov Telescope Array (CTA) <www.cta-observatory.org>`_.
@@ -28,6 +30,7 @@ Resources
 - Current performance: `RedMine <https://forge.in2p3.fr/projects/benchmarks-reference-analysis/wiki/Protopipe_performance_data>`__
 
 - Slack channels:
+
   - `#protopipe <https://cta-aswg.slack.com/archives/CPTN4U7U7>`__
   - `#protopipe_github <https://cta-aswg.slack.com/archives/CPUSPPHST>`__
   - `#protopipe-grid <https://cta-aswg.slack.com/archives/C01FWH8E0TT>`__
@@ -38,7 +41,7 @@ Citing this software
 If you use a released version of this software for a publication,
 please cite it by using the corresponding DOI.
 
-Please, check the development version of this file for up-to-date links.
-
-- v0.3.0 : |doilatest|
+- latest : |doilatest|
 - v0.4.0 : TBD
+- v0.3.0 : |doi_v0.3.0|
+

--- a/docs/install/development.rst
+++ b/docs/install/development.rst
@@ -4,15 +4,14 @@ Development version
 ===================
 
   1. `fork <https://help.github.com/en/articles/fork-a-repo>`__ the `repository <https://github.com/cta-observatory/protopipe>`_
-  2. ``conda env create -f environment.yml``
-  3. ``conda activate protopipe``
-  4. ``pip install -e .``
-
-In this way, you will always use the version of the source code on which you
-are working.
+  2. create and enter a basic virtual environment (or use the ``environment.yaml`` file)
+  3. ``pip install -e '.[all]'``
+  
+  The ``all`` keyword will install all extra requirements,
+  which can be also installed separately using ``tests`` and ``docs``.
 
 Next steps:
 
   * get accustomed to the basic pipeline workflow (:ref:`use-pipeline`),
   * make your own complete analysis (:ref:`use-grid`),
-  * for bugs and new features, please contribute to the project (:ref:`contribute`).
+  * learn how to contribute to the project (:ref:`contribute`).

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -3,24 +3,30 @@
 Installation
 ============
 
-The only requirement is an Anaconda (or Miniconda) installation which supports
-Python 3.
+Requirements:
 
-There are two different ways to install `protopipe`,
+- ``Python >= 3.7``
+- ``pip``
+
+It is recommended to work within a virtual environment, using for example
+``venv`` or Anaconda's ``conda``. 
+
+.. note::
+  In case you want to use Anaconda it is recommended to use
+  `mamba <https://github.com/mamba-org/mamba#readme>`__
+  for improved speed during the creation of the virtual environment.
+
+There are two different ways to install ``protopipe``,
 
 * if you just want to use it as it is (:ref:`install-release`),
 * or if you also want to develop it (:ref:`install-development`).
-
-.. note::
-  For both types of installation the use of `mamba <https://github.com/mamba-org/mamba#readme>`__
-  might provide improved speed during the creation of the `conda` environment.
 
 In both cases, if you want to perform a full analysis, you will need some
 computational power in order to produce enough
 data files for model and performance estimation.
 This can be accomplished through the use of a GRID environment.
 
-After installing `protopipe`,
+After installing ``protopipe``,
 
 * install the code necessary to interface it with the grid (:ref:`install-grid`),
 * use protopipe on the grid (:ref:`use-grid`).

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -21,10 +21,14 @@ There are two different ways to install ``protopipe``,
 * if you just want to use it as it is (:ref:`install-release`),
 * or if you also want to develop it (:ref:`install-development`).
 
-In both cases, if you want to perform a full analysis, you will need some
-computational power in order to produce enough
-data files for model and performance estimation.
-This can be accomplished through the use of a GRID environment.
+In both cases it is suggested to integrate the virtual environment with
+
+- ``jupyterlab`` to execute the benchmarking notebooks and optionally 
+- ``vitables`` to open data files stored as HDF5 tables.
+
+To perform full analyses, you will need some computational power in order to 
+produce enough data files for model and performance estimation.
+This can be accomplished through the use of the DIRAC computing grid.
 
 After installing ``protopipe``,
 

--- a/docs/install/release.rst
+++ b/docs/install/release.rst
@@ -3,11 +3,17 @@
 Released version
 ================
 
-1. download the `latest released version <https://github.com/cta-observatory/protopipe/releases>`__
-2. ``cd protopipe-X.Y.Z``
-3. ``conda env create -f environment.yml -n protopipe-X.Y.Z``
-4. ``conda activate protopipe``
-5. ``pip install .``
+You can find all released versions .
+
+To install a released version >= ``0.4.0`` it is sufficient to install the
+package from ``PyPI`` with ``pip install protopipe``.
+
+For previous releases,
+
+1. download the corresponding tarball stored `here <https://github.com/cta-observatory/protopipe/releases>`__
+2. ``conda env create -f environment.yml -n protopipe-X.Y.Z``
+3. ``conda activate protopipe-X.Y.Z``
+4. ``pip install .``
 
 Next steps:
 

--- a/docs/install/release.rst
+++ b/docs/install/release.rst
@@ -3,8 +3,6 @@
 Released version
 ================
 
-You can find all released versions .
-
 To install a released version >= ``0.4.0`` it is sufficient to install the
 package from ``PyPI`` with ``pip install protopipe``.
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,27 +5,21 @@ channels:
 dependencies:
   - pip
   - ctapipe=0.9.1
-  #- conda-forge::gammapy
+  - conda-forge::gammapy
   - ctapipe-extra
   - astropy>=4.0.1
   - h5py=2
   - ipython
   - jupyterlab
-  #- conda-forge::nbsphinx
+  - conda-forge::nbsphinx
   - notebook
   - numpydoc
   - pandas
   - pytest
-  #- conda-forge::sphinx-automodapi
+  - conda-forge::sphinx-automodapi
   - sphinx_rtd_theme
-  #- conda-forge::sphinx-issues
-  #- conda-forge::uproot
+  - conda-forge::sphinx-issues
+  - conda-forge::uproot
   - conda-forge::vitables
   - pip:
-    - gammapy
-    - nbsphinx
     - pyirf
-    - sphinx-automodapi
-    - sphinx-issues
-    - uproot
-    #- vitables

--- a/protopipe/__init__.py
+++ b/protopipe/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.0.dev0"
+__version__ = "0.4.0.post1"

--- a/protopipe/__init__.py
+++ b/protopipe/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.0-dev"
+__version__ = "0.4.0.dev0"

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "codecov",
+        "ctapipe-extra @ https://github.com/cta-observatory/ctapipe-extra/archive/v0.3.1.tar.gz",
     ],
 }
 
@@ -42,7 +43,7 @@ setup(
     packages=find_packages(),
     package_data={"protopipe": ["aux/example_config_files/protopipe/analysis.yaml"]},
     include_package_data=True,
-    install_requires=["ctapipe"],
+    install_requires=["ctapipe==0.9.1", "jupyterlab", "pyirf", "vitables"],
     zip_safe=False,
     extras_require={
         "all": extras_require["all"],

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(),
     package_data={"protopipe": ["aux/example_config_files/protopipe/analysis.yaml"]},
     include_package_data=True,
-    install_requires=["ctapipe==0.9.1", "jupyterlab", "pyirf", "vitables"],
+    install_requires=["ctapipe==0.9.1", "pyirf"],
     zip_safe=False,
     extras_require={
         "all": extras_require["all"],


### PR DESCRIPTION
This PR prepares the first release that will be uploaded to PyPI as `v0.4.0.post1` by updating the `setup.py` in a way that a pure `pip` installation will be possible with `tests` and `docs` extra requirements.

It is a requirement for PR #105.

It also comes with the following modifications:

- updated installation instructions for both released and development versions
- updated `.zenodo.json` with changes that hopefully will unlock the DOI generation which got stuck with v0.4.0
- updated `README`
- fix `.gitignore` for dummy files generated by `setup.py` and related to versioning