### PR TITLE
Update TRAINING integration tests

### DIFF
--- a/protopipe/aux/example_config_files/analysis.yaml
+++ b/protopipe/aux/example_config_files/analysis.yaml
@@ -2,7 +2,7 @@
 # NOTE: only Prod3b simulations are currently supported.
 General:
  config_name: 'v0.4.0_dev1'
- site: 'south'  # 'north' or 'south'
+ site: 'north'  # 'north' or 'south'
  # array can be either
  # - 'subarray_LSTs', 'subarray_MSTs', 'subarray_SSTs' or 'full_array'
  # - a custom list of telescope IDs
@@ -18,8 +18,8 @@ ImageCleaning:
  biggest:
   tail:  #
    thresholds:  # picture, boundary
-    - LSTCam: [6.61, 3.30]  # TBC
-    - NectarCam: [5.75, 2.88]  # TBC
+    - LSTCam: [6.61, 3.30]
+    - NectarCam: [5.75, 2.88]
     - FlashCam: [4,2] # dummy values for reliable unit-testing
     - ASTRICam: [4,2] # dummy values for reliable unit-testing
     - DigiCam: [0,0] # values left unset for future studies
@@ -52,8 +52,8 @@ ImageCleaning:
  extended:
   tail:  #
    thresholds:  # picture, boundary
-    - LSTCam: [6.61, 3.30]  # TBC
-    - NectarCam: [5.75, 2.88]  # TBC
+    - LSTCam: [6.61, 3.30]
+    - NectarCam: [5.75, 2.88]
     - FlashCam: [4,2] # dummy values for reliable unit-testing
     - ASTRICam: [4,2] # dummy values for reliable unit-testing
     - DigiCam: [0,0] # values left unset for future studies

--- a/protopipe/scripts/tests/test_config_analysis_north.yaml
+++ b/protopipe/scripts/tests/test_config_analysis_north.yaml
@@ -1,0 +1,106 @@
+# General informations
+# NOTE: only Prod3b simulations are currently supported.
+General:
+ config_name: 'v0.4.0_dev1'
+ site: 'north'  # 'north' or 'south'
+ # array can be either
+ # - 'subarray_LSTs', 'subarray_MSTs', 'subarray_SSTs' or 'full_array'
+ # - a custom list of telescope IDs
+ # WARNING: for simulations containing multiple copies of the telescopes,
+ # only 'full_array' or custom list are supported options!
+ array: full_array
+ cam_id_list : ['LSTCam', 'NectarCam'] # Selected cameras (disabled option)
+
+# Cleaning for reconstruction
+ImageCleaning:
+
+ # Cleaning for reconstruction
+ biggest:
+  tail:  #
+   thresholds:  # picture, boundary
+    - LSTCam: [6.61, 3.30]
+    - NectarCam: [5.75, 2.88]
+    - FlashCam: [4,2] # dummy values for reliable unit-testing
+    - ASTRICam: [4,2] # dummy values for reliable unit-testing
+    - DigiCam: [0,0] # values left unset for future studies
+    - CHEC: [0,0] # values left unset for future studies
+    - SCTCam: [0,0] # values left unset for future studies
+   keep_isolated_pixels: False
+   min_number_picture_neighbors: 1
+
+  wave:
+   # Directory to write temporary files
+   #tmp_files_directory: '/dev/shm/'
+   tmp_files_directory: './'
+   options:
+    LSTCam:
+     type_of_filtering: 'hard_filtering'
+     filter_thresholds: [3, 0.2]
+     last_scale_treatment: 'drop'
+     kill_isolated_pixels: True
+     detect_only_positive_structures: False
+     clusters_threshold: 0
+    NectarCam:  # TBC
+     type_of_filtering: 'hard_filtering'
+     filter_thresholds: [3, 0.2]
+     last_scale_treatment: 'drop'
+     kill_isolated_pixels: True
+     detect_only_positive_structures: False
+     clusters_threshold: 0
+
+ # Cleaning for energy/score estimation
+ extended:
+  tail:  #
+   thresholds:  # picture, boundary
+    - LSTCam: [6.61, 3.30]
+    - NectarCam: [5.75, 2.88]
+    - FlashCam: [4,2] # dummy values for reliable unit-testing
+    - ASTRICam: [4,2] # dummy values for reliable unit-testing
+    - DigiCam: [0,0] # values left unset for future studies
+    - CHEC: [0,0] # values left unset for future studies
+    - SCTCam: [0,0] # values left unset for future studies
+   keep_isolated_pixels: False
+   min_number_picture_neighbors: 1
+
+  wave:
+   # Directory to write temporary files
+   #tmp_files_directory: '/dev/shm/'
+   tmp_files_directory: './'
+   options:
+    LSTCam:
+     type_of_filtering: 'hard_filtering'
+     filter_thresholds: [3, 0.2]
+     last_scale_treatment: 'posmask'
+     kill_isolated_pixels: True
+     detect_only_positive_structures: False
+     clusters_threshold: 0
+    NectarCam:  # TBC
+     type_of_filtering: 'hard_filtering'
+     filter_thresholds: [3, 0.2]
+     last_scale_treatment: 'posmask'
+     kill_isolated_pixels: True
+     detect_only_positive_structures: False
+     clusters_threshold: 0
+
+# Cut for image selection
+ImageSelection:
+ charge: [50., 1e10]
+ pixel: [3, 1e10]
+ ellipticity: [0.1, 0.6]
+ nominal_distance: [0., 0.8]  # in camera radius
+
+# Minimal number of telescopes to consider events
+Reconstruction:
+ min_tel: 2
+
+# Parameters for energy estimation
+EnergyRegressor:
+ # Name of the regression method (e.g. AdaBoostRegressor, etc.)
+ method_name: 'AdaBoostRegressor'
+
+# Parameters for g/h separation
+GammaHadronClassifier:
+ # Name of the classification method (e.g. AdaBoostRegressor, etc.)
+ method_name: 'RandomForestClassifier'
+ # Use probability output or score
+ use_proba: True

--- a/protopipe/scripts/tests/test_config_analysis_south.yaml
+++ b/protopipe/scripts/tests/test_config_analysis_south.yaml
@@ -1,0 +1,106 @@
+# General informations
+# NOTE: only Prod3b simulations are currently supported.
+General:
+ config_name: 'v0.4.0_dev1'
+ site: 'south'  # 'north' or 'south'
+ # array can be either
+ # - 'subarray_LSTs', 'subarray_MSTs', 'subarray_SSTs' or 'full_array'
+ # - a custom list of telescope IDs
+ # WARNING: for simulations containing multiple copies of the telescopes,
+ # only 'full_array' or custom list are supported options!
+ array: full_array
+ cam_id_list : ['LSTCam', 'NectarCam'] # Selected cameras (disabled option)
+
+# Cleaning for reconstruction
+ImageCleaning:
+
+ # Cleaning for reconstruction
+ biggest:
+  tail:  #
+   thresholds:  # picture, boundary
+    - LSTCam: [6.61, 3.30]
+    - NectarCam: [5.75, 2.88]
+    - FlashCam: [4,2] # dummy values for reliable unit-testing
+    - ASTRICam: [4,2] # dummy values for reliable unit-testing
+    - DigiCam: [0,0] # values left unset for future studies
+    - CHEC: [0,0] # values left unset for future studies
+    - SCTCam: [0,0] # values left unset for future studies
+   keep_isolated_pixels: False
+   min_number_picture_neighbors: 1
+
+  wave:
+   # Directory to write temporary files
+   #tmp_files_directory: '/dev/shm/'
+   tmp_files_directory: './'
+   options:
+    LSTCam:
+     type_of_filtering: 'hard_filtering'
+     filter_thresholds: [3, 0.2]
+     last_scale_treatment: 'drop'
+     kill_isolated_pixels: True
+     detect_only_positive_structures: False
+     clusters_threshold: 0
+    NectarCam:  # TBC
+     type_of_filtering: 'hard_filtering'
+     filter_thresholds: [3, 0.2]
+     last_scale_treatment: 'drop'
+     kill_isolated_pixels: True
+     detect_only_positive_structures: False
+     clusters_threshold: 0
+
+ # Cleaning for energy/score estimation
+ extended:
+  tail:  #
+   thresholds:  # picture, boundary
+    - LSTCam: [6.61, 3.30]
+    - NectarCam: [5.75, 2.88]
+    - FlashCam: [4,2] # dummy values for reliable unit-testing
+    - ASTRICam: [4,2] # dummy values for reliable unit-testing
+    - DigiCam: [0,0] # values left unset for future studies
+    - CHEC: [0,0] # values left unset for future studies
+    - SCTCam: [0,0] # values left unset for future studies
+   keep_isolated_pixels: False
+   min_number_picture_neighbors: 1
+
+  wave:
+   # Directory to write temporary files
+   #tmp_files_directory: '/dev/shm/'
+   tmp_files_directory: './'
+   options:
+    LSTCam:
+     type_of_filtering: 'hard_filtering'
+     filter_thresholds: [3, 0.2]
+     last_scale_treatment: 'posmask'
+     kill_isolated_pixels: True
+     detect_only_positive_structures: False
+     clusters_threshold: 0
+    NectarCam:  # TBC
+     type_of_filtering: 'hard_filtering'
+     filter_thresholds: [3, 0.2]
+     last_scale_treatment: 'posmask'
+     kill_isolated_pixels: True
+     detect_only_positive_structures: False
+     clusters_threshold: 0
+
+# Cut for image selection
+ImageSelection:
+ charge: [50., 1e10]
+ pixel: [3, 1e10]
+ ellipticity: [0.1, 0.6]
+ nominal_distance: [0., 0.8]  # in camera radius
+
+# Minimal number of telescopes to consider events
+Reconstruction:
+ min_tel: 2
+
+# Parameters for energy estimation
+EnergyRegressor:
+ # Name of the regression method (e.g. AdaBoostRegressor, etc.)
+ method_name: 'AdaBoostRegressor'
+
+# Parameters for g/h separation
+GammaHadronClassifier:
+ # Name of the classification method (e.g. AdaBoostRegressor, etc.)
+ method_name: 'RandomForestClassifier'
+ # Use probability output or score
+ use_proba: True

--- a/protopipe/scripts/tests/test_dataTraining.py
+++ b/protopipe/scripts/tests/test_dataTraining.py
@@ -18,8 +18,6 @@ ana_config = resource_filename("protopipe", "aux/example_config_files/analysis.y
 
 # TEST FILES
 
-DEFAULT_URL = "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.3/"
-
 # Prod 2
 
 # CTA_SOUTH = get_dataset_path("gamma_test_large.simtel.gz")

--- a/protopipe/scripts/tests/test_dataTraining.py
+++ b/protopipe/scripts/tests/test_dataTraining.py
@@ -71,7 +71,7 @@ def test_dataTraining_withImages():
         -o test_training_withImages.h5\
         -m 10\
         --save_images\
-        -i {path.dirname(CTA_NORTH)}\
-        -f {path.basename(CTA_NORTH)}"
+        -i {path.dirname(input_file)}\
+        -f {path.basename(input_file)}"
     )
     assert exit_status == 0

--- a/protopipe/scripts/tests/test_dataTraining.py
+++ b/protopipe/scripts/tests/test_dataTraining.py
@@ -10,26 +10,21 @@ TODO
 """
 from os import path, system
 from pkg_resources import resource_filename
+
+import pytest
+
 from protopipe.scripts import data_training
 from protopipe.pipeline.temp import get_dataset_path
 
-# configuration files
-ana_config = resource_filename("protopipe", "aux/example_config_files/analysis.yaml")
-
 # TEST FILES
-
-# Prod 2
-
-# CTA_SOUTH = get_dataset_path("gamma_test_large.simtel.gz")
 
 # PROD 3b
 
-CTA_NORTH = get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz")
+PROD3B_CTA_NORTH = get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz")
+PROD3B_CTA_SOUTH = get_dataset_path("gamma_Paranal_baseline_20Zd_180Az_prod3_test.simtel.gz")
 
-
-
-
-def test_dataTraining_noImages():
+@pytest.mark.parametrize("input_file",[PROD3B_CTA_NORTH, PROD3B_CTA_SOUTH])
+def test_dataTraining_noImages(input_file):
     """Very bare test to see if the script reaches the end correctly.
 
     WARNING: some of the cuts in the example config file are not optimized for
@@ -37,17 +32,24 @@ def test_dataTraining_noImages():
     In any case, it is expected that in absence of fatal bugs, the script
     ends successfully.
     """
+    
+    # the difference is only the 'site' key as a check for the user
+    if "Paranal" in str(input_file):
+        ana_config = resource_filename("protopipe", "scripts/tests/test_config_analysis_south.yaml")
+    else:
+        ana_config = resource_filename("protopipe", "scripts/tests/test_config_analysis_north.yaml")
+    
     exit_status = system(
         f"python {data_training.__file__}\
         --config_file {ana_config}\
         -o test_training_noImages.h5\
         -m 10\
-        -i {path.dirname(CTA_NORTH)}\
-        -f {path.basename(CTA_NORTH)}"
+        -i {path.dirname(input_file)}\
+        -f {path.basename(input_file)}"
     )
     assert exit_status == 0
 
-
+@pytest.mark.parametrize("input_file",[PROD3B_CTA_NORTH, PROD3B_CTA_SOUTH])
 def test_dataTraining_withImages():
     """Very bare test to see if the script reaches the end correctly.
 
@@ -56,6 +58,13 @@ def test_dataTraining_withImages():
     In any case, it is expected that in absence of fatal bugs, the script
     ends successfully.
     """
+    
+    # the difference is only the 'site' key as a check for the user
+    if "Paranal" in str(input_file):
+        ana_config = resource_filename("protopipe", "scripts/tests/test_config_analysis_south.yaml")
+    else:
+        ana_config = resource_filename("protopipe", "scripts/tests/test_config_analysis_north.yaml")
+    
     exit_status = system(
         f"python {data_training.__file__}\
         --config_file {ana_config}\

--- a/protopipe/scripts/tests/test_dataTraining.py
+++ b/protopipe/scripts/tests/test_dataTraining.py
@@ -1,20 +1,34 @@
-"""Test the data training script in a variety of conditions."""
+"""Test the data training script.
+
+TODO
+----
+
+- test only diffuse data (more general case)
+- add Paranal diffuse test file
+- add Prod5 test files
+
+"""
 from os import path, system
 from pkg_resources import resource_filename
 from protopipe.scripts import data_training
-from ctapipe.utils import get_dataset_path
-
-# TEST FILES
-# 110 events, 98 telescopes at Paranal.
-# Instruments tested: LST_LST_LSTCam, MST_MST_FlashCam, SST_ASTRI_ASTRICam
-GAMMA_TEST_LARGE = get_dataset_path("gamma_test_large.simtel.gz")
-# WARNING: absolutely not sufficient!
-# This is just the only file easily usable without external resources.
-# Later on, we will need a sub-simtel file from each of the
-# MC productions expected to be analyzed with protopipe.
+from protopipe.pipeline.temp import get_dataset_path
 
 # configuration files
 ana_config = resource_filename("protopipe", "aux/example_config_files/analysis.yaml")
+
+# TEST FILES
+
+DEFAULT_URL = "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.3/"
+
+# Prod 2
+
+# CTA_SOUTH = get_dataset_path("gamma_test_large.simtel.gz")
+
+# PROD 3b
+
+CTA_NORTH = get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz")
+
+
 
 
 def test_dataTraining_noImages():
@@ -30,8 +44,9 @@ def test_dataTraining_noImages():
         --config_file {ana_config}\
         -o test_training_noImages.h5\
         -m 10\
-        -i {path.dirname(GAMMA_TEST_LARGE)}\
-        -f {path.basename(GAMMA_TEST_LARGE)}"
+        --debug\
+        -i {path.dirname(CTA_NORTH)}\
+        -f {path.basename(CTA_NORTH)}"
     )
     assert exit_status == 0
 
@@ -50,7 +65,7 @@ def test_dataTraining_withImages():
         -o test_training_withImages.h5\
         -m 10\
         --save_images\
-        -i {path.dirname(GAMMA_TEST_LARGE)}\
-        -f {path.basename(GAMMA_TEST_LARGE)}"
+        -i {path.dirname(CTA_NORTH)}\
+        -f {path.basename(CTA_NORTH)}"
     )
     assert exit_status == 0

--- a/protopipe/scripts/tests/test_dataTraining.py
+++ b/protopipe/scripts/tests/test_dataTraining.py
@@ -23,7 +23,8 @@ from protopipe.pipeline.temp import get_dataset_path
 PROD3B_CTA_NORTH = get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz")
 PROD3B_CTA_SOUTH = get_dataset_path("gamma_Paranal_baseline_20Zd_180Az_prod3_test.simtel.gz")
 
-@pytest.mark.parametrize("input_file",[PROD3B_CTA_NORTH, PROD3B_CTA_SOUTH])
+
+@pytest.mark.parametrize("input_file", [PROD3B_CTA_NORTH, PROD3B_CTA_SOUTH])
 def test_dataTraining_noImages(input_file):
     """Very bare test to see if the script reaches the end correctly.
 
@@ -32,13 +33,13 @@ def test_dataTraining_noImages(input_file):
     In any case, it is expected that in absence of fatal bugs, the script
     ends successfully.
     """
-    
+
     # the difference is only the 'site' key as a check for the user
     if "Paranal" in str(input_file):
         ana_config = resource_filename("protopipe", "scripts/tests/test_config_analysis_south.yaml")
     else:
         ana_config = resource_filename("protopipe", "scripts/tests/test_config_analysis_north.yaml")
-    
+
     exit_status = system(
         f"python {data_training.__file__}\
         --config_file {ana_config}\
@@ -49,8 +50,9 @@ def test_dataTraining_noImages(input_file):
     )
     assert exit_status == 0
 
-@pytest.mark.parametrize("input_file",[PROD3B_CTA_NORTH, PROD3B_CTA_SOUTH])
-def test_dataTraining_withImages():
+
+@pytest.mark.parametrize("input_file", [PROD3B_CTA_NORTH, PROD3B_CTA_SOUTH])
+def test_dataTraining_withImages(input_file):
     """Very bare test to see if the script reaches the end correctly.
 
     WARNING: some of the cuts in the example config file are not optimized for
@@ -58,13 +60,13 @@ def test_dataTraining_withImages():
     In any case, it is expected that in absence of fatal bugs, the script
     ends successfully.
     """
-    
+
     # the difference is only the 'site' key as a check for the user
     if "Paranal" in str(input_file):
         ana_config = resource_filename("protopipe", "scripts/tests/test_config_analysis_south.yaml")
     else:
         ana_config = resource_filename("protopipe", "scripts/tests/test_config_analysis_north.yaml")
-    
+
     exit_status = system(
         f"python {data_training.__file__}\
         --config_file {ana_config}\

--- a/protopipe/scripts/tests/test_dataTraining.py
+++ b/protopipe/scripts/tests/test_dataTraining.py
@@ -11,6 +11,7 @@ TODO
 from os import path, system
 from pkg_resources import resource_filename
 
+import tables
 import pytest
 
 from protopipe.scripts import data_training
@@ -48,7 +49,13 @@ def test_dataTraining_noImages(input_file):
         -i {path.dirname(input_file)}\
         -f {path.basename(input_file)}"
     )
+
+    # check that the script ends without crashing
     assert exit_status == 0
+
+    # check that the produced HDF5 file is non-empty
+    with tables.open_file("test_training_noImages.h5") as file:
+        assert file.get_filesize() > 0
 
 
 @pytest.mark.parametrize("input_file", [PROD3B_CTA_NORTH, PROD3B_CTA_SOUTH])
@@ -76,4 +83,10 @@ def test_dataTraining_withImages(input_file):
         -i {path.dirname(input_file)}\
         -f {path.basename(input_file)}"
     )
+
+    # check that the script ends without crashing
     assert exit_status == 0
+
+    # check that the produced HDF5 file is non-empty
+    with tables.open_file("test_training_noImages.h5") as file:
+        assert file.get_filesize() > 0

--- a/protopipe/scripts/tests/test_dataTraining.py
+++ b/protopipe/scripts/tests/test_dataTraining.py
@@ -42,7 +42,6 @@ def test_dataTraining_noImages():
         --config_file {ana_config}\
         -o test_training_noImages.h5\
         -m 10\
-        --debug\
         -i {path.dirname(CTA_NORTH)}\
         -f {path.basename(CTA_NORTH)}"
     )


### PR DESCRIPTION
### In this PR

- [x] Use Prod3b test files
- [x] Use `get_dataset_path` from latest ctapipe to be already set up for use of the cc-in2p3 dataserver

### other things to do (ctapipe extra resources)

- add proper diffuse test file for prod3b (see cta-observatory/ctapipe-extra#34)
- add Prod5 file

so we would be able to

-  test on diffuse data only
-  test already on prod5

### what we should add more

- [x] add the possibility to test on multiple files
- [x] add a very simple check on HDF5 output file (e.g. non-empty should be sufficient)
