### PR TITLE
Small improvements to modeling script

### DIFF
--- a/docs/mva/index.rst
+++ b/docs/mva/index.rst
@@ -17,41 +17,20 @@ output for the event (energy or score/gammaness).
 Details
 -------
 
+Data is split in train and test subsamples by images.
+
 The class `TrainModel` uses a training sample composed of gamma-rays for a
 regression model. In addition of a gamma-ray sample, a sample of
 protons is also used to build a classifier. The training of a model is done via
 the GridSearchCV_ algorithm which allows to find the best hyper-parameters of
 the models.
 
-The RegressorDiagnostic and ClassifierDiagnostic classes can be used to generate
-several diagnostic plots for regression and classification models, respectively.
-
-Proposals for improvements and/or fixes
----------------------------------------
-
-.. note::
-
-  This section has to be moved to the repository as a set of issues.
-
-* Improve split of training/test data. For now the split of the data is done
-  according to the run number, e.g. training data will be N% of the first runs
-  (sorted by run numbers) and test data will be the remaining runs. Really easy
-  to improve with scikit-learn. But I wanted to keep the information about evt_id and
-  the obs_id in order to combine the data and produce diagnostic plot at the
-  level of event (not implemented yet), which is more complex that what scikit does.
-* Implement event-level diagnostic.
-* To train the energy estimator, the Boosted Decision Tree method is hard-coded.
-* For the diagnostic, in both case we might want to implement diagnostics
-  at the level of events but for this we need to link the event Id with the
-  observation Id as well as the image parameters to split and combine the
-  model output. It needs some thoughts...
-
 Reference/API
 -------------
 
 .. automodapi:: protopipe.mva
     :no-inheritance-diagram:
-    :skip: auc, roc_curve
+    :skip: auc, roc_curve, train_test_split
 
 .. _scikit-learn: https://scikit-learn.org/
 .. _GridSearchCV: https://scikit-learn.org/stable/modules/grid_search.html

--- a/docs/scripts/DL2.rst
+++ b/docs/scripts/DL2.rst
@@ -15,13 +15,14 @@ By invoking the help argument, you can get help about how the script works:
 
 .. code-block::
 
-  usage: write_dl2.py [-h] --config_file CONFIG_FILE -o OUTFILE [-m MAX_EVENTS]
-                    [-i INDIR] [-f [INFILE_LIST [INFILE_LIST ...]]]
-                    [--wave_dir WAVE_DIR] [--wave_temp_dir WAVE_TEMP_DIR]
-                    [--wave | --tail] [--regressor_dir REGRESSOR_DIR]
-                    [--classifier_dir CLASSIFIER_DIR]
-                    [--force_tailcut_for_extended_cleaning FORCE_TAILCUT_FOR_EXTENDED_CLEANING]
-                    [--save_images]
+  usage: protopipe-DL2 [-h] --config_file CONFIG_FILE -o OUTFILE [-m MAX_EVENTS]
+                       [-i INDIR] [-f [INFILE_LIST [INFILE_LIST ...]]]
+                       [--cam_ids [CAM_IDS [CAM_IDS ...]]] [--wave_dir WAVE_DIR]
+                       [--wave_temp_dir WAVE_TEMP_DIR] [--wave | --tail]
+                       [--debug] [--regressor_dir REGRESSOR_DIR]
+                       [--classifier_dir CLASSIFIER_DIR]
+                       [--force_tailcut_for_extended_cleaning FORCE_TAILCUT_FOR_EXTENDED_CLEANING]
+                       [--save_images]
 
   optional arguments:
     -h, --help            show this help message and exit
@@ -32,6 +33,8 @@ By invoking the help argument, you can get help about how the script works:
     -i INDIR, --indir INDIR
     -f [INFILE_LIST [INFILE_LIST ...]], --infile_list [INFILE_LIST [INFILE_LIST ...]]
                           give a specific list of files to run on
+    --cam_ids [CAM_IDS [CAM_IDS ...]]
+                          give the specific list of camera types to run on
     --wave_dir WAVE_DIR   directory where to find mr_filter. if not set look in
                           $PATH
     --wave_temp_dir WAVE_TEMP_DIR
@@ -39,6 +42,7 @@ By invoking the help argument, you can get help about how the script works:
                           files
     --wave                if set, use wavelet cleaning -- default
     --tail                if set, use tail cleaning, otherwise wavelets
+    --debug               Print debugging information
     --regressor_dir REGRESSOR_DIR
                           regressors directory
     --classifier_dir CLASSIFIER_DIR

--- a/docs/scripts/data_training.rst
+++ b/docs/scripts/data_training.rst
@@ -19,40 +19,41 @@ By invoking the help argument, you can get help about how the script works:
 
 .. code-block::
 
-  usage: data_training.py [-h] --config_file CONFIG_FILE -o OUTFILE
-                      [-m MAX_EVENTS] [-i INDIR]
-                      [-f [INFILE_LIST [INFILE_LIST ...]]]
-                      [--cam_ids [CAM_IDS [CAM_IDS ...]]]
-                      [--wave_dir WAVE_DIR] [--wave_temp_dir WAVE_TEMP_DIR]
-                      [--wave | --tail] [--debug] [--save_images]
-                      [--estimate_energy ESTIMATE_ENERGY]
-                      [--regressor_dir REGRESSOR_DIR]
+  usage: protopipe-TRAINING [-h] --config_file CONFIG_FILE -o OUTFILE
+                            [-m MAX_EVENTS] [-i INDIR]
+                            [-f [INFILE_LIST [INFILE_LIST ...]]]
+                            [--cam_ids [CAM_IDS [CAM_IDS ...]]]
+                            [--wave_dir WAVE_DIR]
+                            [--wave_temp_dir WAVE_TEMP_DIR] [--wave | --tail]
+                            [--debug] [--save_images]
+                            [--estimate_energy ESTIMATE_ENERGY]
+                            [--regressor_dir REGRESSOR_DIR]
 
   optional arguments:
-  -h, --help            show this help message and exit
-  --config_file CONFIG_FILE
-  -o OUTFILE, --outfile OUTFILE
-  -m MAX_EVENTS, --max_events MAX_EVENTS
-                        maximum number of events considered per file
-  -i INDIR, --indir INDIR
-  -f [INFILE_LIST [INFILE_LIST ...]], --infile_list [INFILE_LIST [INFILE_LIST ...]]
-                        give a specific list of files to run on
-  --cam_ids [CAM_IDS [CAM_IDS ...]]
-                        give the specific list of camera types to run on
-  --wave_dir WAVE_DIR   directory where to find mr_filter. if not set look in
-                        $PATH
-  --wave_temp_dir WAVE_TEMP_DIR
-                        directory where mr_filter to store the temporary fits
-                        files
-  --wave                if set, use wavelet cleaning -- default
-  --tail                if set, use tail cleaning, otherwise wavelets
-  --debug               Print debugging information
-  --save_images         Save also all images
-  --estimate_energy ESTIMATE_ENERGY
-                        Estimate the events' energy with a regressor from
-                        protopipe.scripts.build_model
-  --regressor_dir REGRESSOR_DIR
-                        regressors directory
+    -h, --help            show this help message and exit
+    --config_file CONFIG_FILE
+    -o OUTFILE, --outfile OUTFILE
+    -m MAX_EVENTS, --max_events MAX_EVENTS
+                          maximum number of events considered per file
+    -i INDIR, --indir INDIR
+    -f [INFILE_LIST [INFILE_LIST ...]], --infile_list [INFILE_LIST [INFILE_LIST ...]]
+                          give a specific list of files to run on
+    --cam_ids [CAM_IDS [CAM_IDS ...]]
+                          give the specific list of camera types to run on
+    --wave_dir WAVE_DIR   directory where to find mr_filter. if not set look in
+                          $PATH
+    --wave_temp_dir WAVE_TEMP_DIR
+                          directory where mr_filter to store the temporary fits
+                          files
+    --wave                if set, use wavelet cleaning -- default
+    --tail                if set, use tail cleaning, otherwise wavelets
+    --debug               Print debugging information
+    --save_images         Save also all images
+    --estimate_energy ESTIMATE_ENERGY
+                          Estimate the events' energy with a regressor from
+                          protopipe.scripts.build_model
+    --regressor_dir REGRESSOR_DIR
+                          regressors directory
 
 The configuration file used by this script is ``analysis.yaml``,
 

--- a/docs/scripts/model_building.rst
+++ b/docs/scripts/model_building.rst
@@ -10,24 +10,38 @@ The base classes are defined in the ``protopipe.mva`` module (see :ref:`mva`).
 For both cases, building a regressor or a classifier, the script
 ``protopipe.scripts.build_model.py`` is used.
 
-The following is a summary of ist usage required arguments and options.
+The following is the help output which shows required arguments and options.
 
 .. code-block::
 
-    >$ ./build_model.py --help
-    usage: build_model.py [-h] --config_file CONFIG_FILE [--max_events MAX_EVENTS]
-                      [--wave | --tail]
+    >$ protopipe-MODEL -h
+    usage: protopipe-MODEL [-h] --config_file CONFIG_FILE
+                       [--max_events MAX_EVENTS] [--wave | --tail]
+                       (--cameras_from_config | --cameras_from_file | --cam_id_list CAM_ID_LIST)
+                       [-i INDIR] [--infile_signal INFILE_SIGNAL]
+                       [--infile_background INFILE_BACKGROUND] [-o OUTDIR]
 
     Build model for regression/classification
 
     optional arguments:
       -h, --help            show this help message and exit
-      --config_file         CONFIG_FILE
-      --max_events          maximum number of events for training
+      --config_file CONFIG_FILE
+      --max_events MAX_EVENTS
+                            maximum number of events for training
       --wave                if set, use wavelet cleaning
       --tail                if set, use tail cleaning, otherwise wavelets
-
-The last two options can be ignored.
+      --cameras_from_config
+                            Get cameras configuration file (Priority 1)
+      --cameras_from_file   Get cameras from input file (Priority 2)
+      --cam_id_list CAM_ID_LIST
+                            Select cameras like 'LSTCam CHEC' (Priority 3)
+      -i INDIR, --indir INDIR
+                            Directory containing the required input file(s)
+      --infile_signal INFILE_SIGNAL
+                            SIGNAL file (default: read from config file)
+      --infile_background INFILE_BACKGROUND
+                            BACKGROUND file (default: read from config file)
+      -o OUTDIR, --outdir OUTDIR
 
 The script takes along its arguments a configuration file which depends on what
 type of estimator needs to be trained:

--- a/docs/scripts/optimization_cuts_IRFs.rst
+++ b/docs/scripts/optimization_cuts_IRFs.rst
@@ -26,8 +26,8 @@ The script ``protopipe.scripts.make_performance_EventDisplay.py`` is used as fol
 
 .. code-block::
 
-  usage: make_performance_EventDisplay.py [-h] --config_file CONFIG_FILE
-                                          [--wave | --tail]
+  usage: protopipe-DL3-EventDisplay [-h] --config_file CONFIG_FILE
+                                  [--wave | --tail]
 
   Make performance files
 

--- a/protopipe/mva/train_model.py
+++ b/protopipe/mva/train_model.py
@@ -57,7 +57,7 @@ class TrainModel(object):
                 self.data_train,
                 self.data_test,
             ) = split_train_test(
-                ds=data_sig,
+                survived_images=data_sig,
                 train_fraction=train_fraction,
                 feature_name_list=self.feature_name_list,
                 target_name=self.target_name,

--- a/protopipe/mva/utils.py
+++ b/protopipe/mva/utils.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pickle
 import gzip
 from sklearn.metrics import auc, roc_curve
+from sklearn.model_selection import train_test_split
 
 
 def save_obj(obj, name):
@@ -45,23 +46,48 @@ def make_cut_list(cuts):
     return cut_list
 
 
-def split_train_test(ds, train_fraction, feature_name_list, target_name):
-    # Get the run id corresponding to 70% of the statistics
-    # (and sort to avoid troubles...)
-    obs_ids = np.sort(pd.unique(ds["obs_id"]))
-    max_train_obs_idx = int(train_fraction * len(obs_ids))
-    run_max_train = obs_ids[max_train_obs_idx]
+def split_train_test(survived_images, train_fraction, feature_name_list, target_name):
+    """Split the data selected for cuts in train and test samples.
 
-    # Split the data for training
-    data_train = ds.query("obs_id < {}".format(run_max_train))
+    Parameters
+    ----------
+    survived_images: `~pandas.DataFrame`
+        Images that survived the selection cuts.
+    train_fraction: `float`
+        Fraction of data to be used for training.
+    feature_name_list: `list`
+        List of variables to use for training the model.
+    target_name: `str`
+        Variable against which to train.
+
+    Returns
+    --------
+    X_train: `~pandas.DataFrame`
+        Data frame
+    X_test: `~pandas.DataFrame`
+        Data frame
+    y_train: `~pandas.DataFrame`
+        Data frame
+    y_test: `~pandas.DataFrame`
+        Data frame
+    data_train: `~pandas.DataFrame`
+        Training data indexed by observation ID and event ID.
+    data_test: `~pandas.DataFrame`
+        Test data indexed by observation ID and event ID.
+    """
+
+    data_train, data_test = train_test_split(survived_images,
+                                             train_size=train_fraction,
+                                             random_state=0,
+                                             shuffle=True)
+
     y_train = data_train[target_name]
     X_train = data_train[feature_name_list]
-    data_train = data_train.set_index(["obs_id", "event_id"])
 
-    # Split the data for training
-    data_test = ds.query("obs_id >= {}".format(run_max_train))
     y_test = data_test[target_name]
     X_test = data_test[feature_name_list]
+
+    data_train = data_train.set_index(["obs_id", "event_id"])
     data_test = data_test.set_index(["obs_id", "event_id"])
 
     return X_train, X_test, y_train, y_test, data_train, data_test

--- a/protopipe/pipeline/utils.py
+++ b/protopipe/pipeline/utils.py
@@ -1,3 +1,4 @@
+import tables
 import yaml
 import argparse
 import math
@@ -427,7 +428,6 @@ def camera_radius(camid_to_efl, cam_id="all"):
 
 
 def CTAMARS_radii(camera_name):
-
     """Radii of the cameras as defined in CTA-MARS.
 
     These values are defined in the code of CTA-MARS.
@@ -456,3 +456,27 @@ def CTAMARS_radii(camera_name):
     }
 
     return average_camera_radii_deg[camera_name]
+
+
+def get_camera_names(inputPath=None):
+    """Read the names of the cameras.
+
+    Parameters
+    ==========
+    infile : str
+        Full path of the input DL1 file.
+    fileName : str
+        Name of the input DL1 file.
+
+    Returns
+    =======
+    camera_names : list(str)
+        Table names as a list.
+    """
+    if inputPath is None:
+        print("ERROR: check input")
+    h5file = tables.open_file(inputPath, mode='r')
+    group = h5file.get_node("/")
+    camera_names = [x.name for x in group._f_list_nodes()]
+    h5file.close()
+    return camera_names

--- a/protopipe/scripts/build_model.py
+++ b/protopipe/scripts/build_model.py
@@ -50,15 +50,26 @@ def main():
         help="if set, use tail cleaning, otherwise wavelets",
     )
 
-    # if set, these last 4 CLI can overwrite the values from the config
+    # These last CL arguments can overwrite the values from the config
 
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument('--cameras_from_file', action='store_true')
-    group.add_argument('--cameras_from_config', action='store_true')
-    group.add_argument('--cam_id_list', type=str, default=None)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--cameras_from_config',
+                       action='store_true',
+                       help="Get cameras configuration file (Priority 1)",)
+    group.add_argument('--cameras_from_file',
+                       action='store_true',
+                       help="Get cameras from input file (Priority 2)",)
+    group.add_argument('--cam_id_list',
+                       type=str,
+                       default=None,
+                       help="Select cameras like 'LSTCam CHEC' (Priority 3)",)
 
     parser.add_argument(
-        "-i", "--indir", type=str, default=None,
+        "-i",
+        "--indir",
+        type=str,
+        default=None,
+        help="Directory containing the required input file(s)"
     )
     parser.add_argument(
         "--infile_signal",


### PR DESCRIPTION
This PR is the result of some improvement that came out as a consequence of the development of the integration tests for the modeling part.

- the split between train and test data has been simplified/improved by 
  - using the correspondent `scikit-learn` function,
  - splitting on images instead of `obs_id` (more "democratic" choice)
  - shuffling the images against shower reuse in CORSIKA
- the I/O of the script has been improved,
   - input and output information can be overwritten by the CLI, which has lower priority over the config file
   - camera IDs can be read similarly with the following priorities (from higher to lower)
     - from the config file
     - from the training file
     - from the CLI