### PR TITLE
Fix pipeline integration test workflow 

### DIFF
--- a/protopipe/scripts/tests/test_config_analysis_north.yaml
+++ b/protopipe/scripts/tests/test_config_analysis_north.yaml
@@ -1,7 +1,7 @@
 # General informations
 # NOTE: only Prod3b simulations are currently supported.
 General:
- config_name: 'v0.4.0_dev1'
+ config_name: 'test_CTA_North'
  site: 'north'  # 'north' or 'south'
  # array can be either
  # - 'subarray_LSTs', 'subarray_MSTs', 'subarray_SSTs' or 'full_array'

--- a/protopipe/scripts/tests/test_config_analysis_south.yaml
+++ b/protopipe/scripts/tests/test_config_analysis_south.yaml
@@ -1,7 +1,7 @@
 # General informations
 # NOTE: only Prod3b simulations are currently supported.
 General:
- config_name: 'v0.4.0_dev1'
+ config_name: 'test_CTA_South'
  site: 'south'  # 'north' or 'south'
  # array can be either
  # - 'subarray_LSTs', 'subarray_MSTs', 'subarray_SSTs' or 'full_array'

--- a/protopipe/scripts/tests/test_pipeline.py
+++ b/protopipe/scripts/tests/test_pipeline.py
@@ -90,55 +90,6 @@ def test_GET_GAMMAS_FOR_ENERGY_MODEL(test_case, pipeline_testdir):
 
 
 @pytest.mark.parametrize("test_case", [
-    pytest.param("PROD3B_CTA_NORTH", marks=pytest.mark.dependency(name="g2N")),
-    pytest.param("PROD3B_CTA_SOUTH", marks=pytest.mark.dependency(name="g2S")),
-])
-def test_GET_GAMMAS_FOR_CLASSIFICATION_MODEL(test_case, pipeline_testdir):
-
-    outpath = pipeline_testdir / f"test_gamma2_noImages_{test_case}.h5"
-
-    exit_status = system(
-        f"python {data_training.__file__}\
-        --config_file {input_data[test_case]['config']}\
-        -o {outpath}\
-        -i {input_data[test_case]['gamma2'].parent}\
-        -f {input_data[test_case]['gamma2'].name}"
-    )
-
-    # check that the script ends without crashing
-    assert exit_status == 0
-
-    # check that the produced HDF5 file is non-empty
-    with tables.open_file(outpath) as file:
-        assert file.get_filesize() > 0
-
-
-@pytest.mark.parametrize("test_case", [
-    pytest.param("PROD3B_CTA_NORTH", marks=pytest.mark.dependency(name="p1N")),
-    pytest.param("PROD3B_CTA_SOUTH", marks=pytest.mark.dependency(name="p1S")),
-])
-def test_GET_PROTONS_FOR_CLASSIFICATION_MODEL(test_case, pipeline_testdir):
-
-    outpath = pipeline_testdir / f"test_proton1_noImages_{test_case}.h5"
-
-    exit_status = system(
-        f"python {data_training.__file__}\
-        --config_file {input_data[test_case]['config']}\
-        -o {outpath}\
-        -m 10\
-        -i {input_data[test_case]['proton1'].parent}\
-        -f {input_data[test_case]['proton1'].name}"
-    )
-
-    # check that the script ends without crashing
-    assert exit_status == 0
-
-    # check that the produced HDF5 file is non-empty
-    with tables.open_file(outpath) as file:
-        assert file.get_filesize() > 0
-
-
-@pytest.mark.parametrize("test_case", [
     pytest.param("PROD3B_CTA_NORTH", marks=pytest.mark.dependency(name="EN",
                                                                   depends=["g1N"])),
     pytest.param("PROD3B_CTA_SOUTH", marks=pytest.mark.dependency(name="ES",
@@ -160,6 +111,65 @@ def test_BUILD_ENERGY_MODEL_AdaBoost_DecisionTreeRegressor(test_case, pipeline_t
         --cameras_from_file"
     )
     assert exit_status == 0
+
+
+@pytest.mark.parametrize("test_case", [
+    pytest.param("PROD3B_CTA_NORTH", marks=pytest.mark.dependency(name="g2N",
+                                                                  depends=["EN"])),
+    pytest.param("PROD3B_CTA_SOUTH", marks=pytest.mark.dependency(name="g2S",
+                                                                  depends=["ES"])),
+])
+def test_GET_GAMMAS_FOR_CLASSIFICATION_MODEL(test_case, pipeline_testdir):
+
+    modelpath = pipeline_testdir / f"energy_model_{test_case}"
+    outpath = pipeline_testdir / f"test_gamma2_noImages_{test_case}.h5"
+
+    exit_status = system(
+        f"python {data_training.__file__}\
+        --config_file {input_data[test_case]['config']}\
+        -o {outpath}\
+        -i {input_data[test_case]['gamma2'].parent}\
+        -f {input_data[test_case]['gamma2'].name}\
+        --estimate_energy True\
+        --regressor_dir {modelpath}"
+    )
+
+    # check that the script ends without crashing
+    assert exit_status == 0
+
+    # check that the produced HDF5 file is non-empty
+    with tables.open_file(outpath) as file:
+        assert file.get_filesize() > 0
+
+
+@pytest.mark.parametrize("test_case", [
+    pytest.param("PROD3B_CTA_NORTH", marks=pytest.mark.dependency(name="p1N",
+                                                                  depends=["EN"])),
+    pytest.param("PROD3B_CTA_SOUTH", marks=pytest.mark.dependency(name="p1S",
+                                                                  depends=["ES"])),
+])
+def test_GET_PROTONS_FOR_CLASSIFICATION_MODEL(test_case, pipeline_testdir):
+
+    modelpath = pipeline_testdir / f"energy_model_{test_case}"
+    outpath = pipeline_testdir / f"test_proton1_noImages_{test_case}.h5"
+
+    exit_status = system(
+        f"python {data_training.__file__}\
+        --config_file {input_data[test_case]['config']}\
+        -o {outpath}\
+        -m 10\
+        -i {input_data[test_case]['proton1'].parent}\
+        -f {input_data[test_case]['proton1'].name}\
+        --estimate_energy True\
+        --regressor_dir {modelpath}"
+    )
+
+    # check that the script ends without crashing
+    assert exit_status == 0
+
+    # check that the produced HDF5 file is non-empty
+    with tables.open_file(outpath) as file:
+        assert file.get_filesize() > 0
 
 
 @pytest.mark.parametrize("test_case", [


### PR DESCRIPTION
I noticed that I forgot to use the estimated energy (both telescope-wise and event-wise )as a classification parameter as it is done currently in a standard analysis with protopipe.