### PR TITLE
Fix classifier integration test

### DIFF
--- a/protopipe/scripts/tests/test_classifier.yaml
+++ b/protopipe/scripts/tests/test_classifier.yaml
@@ -9,7 +9,7 @@ General:
  outdir: '[...]/shared_folder/analyses/v0.4.0_dev1/estimators/gamma_hadron_classifier'
 
 Split:
- train_fraction: 0.8
+ train_fraction: 0.5
  use_same_number_of_sig_and_bkg_for_training: False  # Lowest statistics will drive the split
 
 Method:

--- a/protopipe/scripts/tests/test_config_analysis_south.yaml
+++ b/protopipe/scripts/tests/test_config_analysis_south.yaml
@@ -86,8 +86,8 @@ ImageCleaning:
 ImageSelection:
  charge: [50., 1e10]
  pixel: [3, 1e10]
- ellipticity: [0.1, 0.6]
- nominal_distance: [0., 0.8]  # in camera radius
+ ellipticity: [0.1, 0.8]
+ nominal_distance: [0., 1.]  # in camera radius
 
 # Minimal number of telescopes to consider events
 Reconstruction:

--- a/protopipe/scripts/tests/test_pipeline.py
+++ b/protopipe/scripts/tests/test_pipeline.py
@@ -188,7 +188,6 @@ def test_GET_PROTONS_FOR_CLASSIFICATION_MODEL(test_case, pipeline_testdir):
     command = f"python {data_training.__file__}\
     --config_file {input_data[test_case]['config']}\
     -o {outpath}\
-    -m 10\
     -i {input_data[test_case]['proton1'].parent}\
     -f {input_data[test_case]['proton1'].name}\
     --estimate_energy True\

--- a/protopipe/scripts/tests/test_pipeline.py
+++ b/protopipe/scripts/tests/test_pipeline.py
@@ -225,7 +225,7 @@ def test_BUILD_CLASSIFICATION_MODEL_RandomForest(test_case, pipeline_testdir):
     infile_background = pipeline_testdir / f"test_proton1_noImages_{test_case}.h5"
     outdir = pipeline_testdir / f"classification_model_{test_case}"
 
-    config = resource_filename("protopipe", "scripts/tests/test_regressor.yaml")
+    config = resource_filename("protopipe", "scripts/tests/test_classifier.yaml")
 
     command = f"python {build_model.__file__}\
     --config_file {config}\


### PR DESCRIPTION
## Requirements

- [x] Merge PR #119 
- [x] Merge PR #122

## Description

This PR fixes an error in the pipeline's testing workflow for which the testing function for the classifier(s) was actually using the energy regressor configuration file, thus not even using protons.

## Caveat

Once this fix has been added the same integration test found an error in the execution of the script to build the models, so right now this PR cannot be merged until that error is fixed in a different PR (but it can be pre-reviewed).