### PR TITLE
Support for ctapipe 0.10.5

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -7,7 +7,7 @@ conda update -q conda  # get latest conda version
 # Useful for debugging any issues with conda
 conda info -a
 
-sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
+sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment_development.yml
 conda install -c conda-forge mamba
-mamba env create -n protopipe --file environment.yml
+mamba env create -n protopipe --file environment_development.yml
 conda activate protopipe

--- a/docs/install/development.rst
+++ b/docs/install/development.rst
@@ -4,11 +4,11 @@ Development version
 ===================
 
   1. `fork <https://help.github.com/en/articles/fork-a-repo>`__ the `repository <https://github.com/cta-observatory/protopipe>`_
-  2. create and enter a basic virtual environment (or use the ``environment.yaml`` file)
+  2. create a virtual environment (Anaconda users can use the ``environment_development.yml`` file)
   3. ``pip install -e '.[all]'``
   
   The ``all`` keyword will install all extra requirements,
-  which can be also installed separately using ``tests`` and ``docs``.
+  which can be also installed separately using ``tests`` and/or ``docs``.
 
 Next steps:
 

--- a/docs/install/release.rst
+++ b/docs/install/release.rst
@@ -3,8 +3,12 @@
 Released version
 ================
 
-To install a released version >= ``0.4.0`` it is sufficient to install the
+To install the latest released version it is sufficient to install the
 package from ``PyPI`` with ``pip install protopipe``.
+
+If you prefer to work from an Anaconda virtual environment you can create it with,
+
+``conda env create -f environment_latest_release.yml``
 
 For previous releases,
 

--- a/docs/pipeline/index.rst
+++ b/docs/pipeline/index.rst
@@ -106,4 +106,4 @@ Reference/API
 .. automodapi:: protopipe.pipeline
     :no-inheritance-diagram:
     :include-all-objects:
-    :skip: event_source
+    :skip: EventSource

--- a/environment_development.yml
+++ b/environment_development.yml
@@ -1,12 +1,11 @@
-name: protopipe
+name: protopipe-dev
 channels:
   - defaults
-  - cta-observatory
 dependencies:
+  - python >=3.7,<3.9
   - pip
-  - ctapipe=0.9.1
+  - conda-forge::ctapipe=0.10.5
   - conda-forge::gammapy
-  - ctapipe-extra
   - astropy>=4.0.1
   - h5py=2
   - ipython
@@ -23,3 +22,4 @@ dependencies:
   - conda-forge::vitables
   - pip:
     - pyirf
+    - pytest-dependency

--- a/environment_latest_release.yml
+++ b/environment_latest_release.yml
@@ -1,0 +1,8 @@
+name: protopipe
+channels:
+  - defaults
+dependencies:
+  - python >=3.7,<3.9
+  - pip
+  - pip:
+    - protopipe

--- a/protopipe/scripts/data_training.py
+++ b/protopipe/scripts/data_training.py
@@ -10,8 +10,7 @@ import signal
 import tables as tb
 
 from ctapipe.utils.CutFlow import CutFlow
-from ctapipe.io import event_source
-from ctapipe.reco.energy_regressor import EnergyRegressor
+from ctapipe.io import EventSource
 
 from protopipe.pipeline import EventPreparer
 from protopipe.pipeline.utils import (
@@ -21,6 +20,7 @@ from protopipe.pipeline.utils import (
     load_config,
     SignalHandler,
     bcolors,
+    load_models,
 )
 
 
@@ -116,7 +116,7 @@ def main():
             }
         )
 
-        regressor = EnergyRegressor.load(reg_file, cam_id_list=cams_and_foclens.keys())
+        regressors = load_models(reg_file, cam_id_list=cams_and_foclens.keys())
 
     # COLUMN DESCRIPTOR AS DICTIONARY
     # Column descriptor for the file containing output training data."""
@@ -207,7 +207,7 @@ def main():
 
         print("file: {} filename = {}".format(i, filename))
 
-        source = event_source(
+        source = EventSource(
             input_url=filename, allowed_tels=allowed_tels, max_events=args.max_events
         )
 
@@ -234,18 +234,15 @@ def main():
             source, save_images=args.save_images, debug=args.debug
         ):
 
-            # Angular quantities
-            run_array_direction = event.mcheader.run_array_direction
-
             if good_event:
 
                 xi = angular_separation(
-                    event.mc.az, event.mc.alt, reco_result.az, reco_result.alt
+                    event.simulation.shower.az, event.simulation.shower.alt, reco_result.az, reco_result.alt
                 )
 
                 offset = angular_separation(
-                    run_array_direction[0],  # az
-                    run_array_direction[1],  # alt
+                    event.pointing.array_azimuth,
+                    event.pointing.array_altitude,
                     reco_result.az,
                     reco_result.alt,
                 )
@@ -295,7 +292,7 @@ def main():
 
                     cam_id = source.subarray.tel[tel_id].camera.camera_name
                     moments = hillas_dict[tel_id]
-                    model = regressor.model_dict[cam_id]
+                    model = regressors[cam_id]
 
                     features_img = np.array(
                         [
@@ -377,7 +374,7 @@ def main():
                 outData[cam_id]["h_max"] = h_max.to("m").value
                 outData[cam_id]["err_est_pos"] = np.nan
                 outData[cam_id]["err_est_dir"] = np.nan
-                outData[cam_id]["true_energy"] = event.mc.energy.to("TeV").value
+                outData[cam_id]["true_energy"] = event.simulation.shower.energy.to("TeV").value
                 outData[cam_id]["hillas_x"] = moments.x.to("deg").value
                 outData[cam_id]["hillas_y"] = moments.y.to("deg").value
                 outData[cam_id]["hillas_phi"] = moments.phi.to("deg").value
@@ -392,13 +389,13 @@ def main():
                 outData[cam_id]["hillas_ellipticity"] = ellipticity.value
                 outData[cam_id]["clusters"] = n_cluster_dict[tel_id]
                 outData[cam_id]["n_tel_discri"] = n_tels["GOOD images"]
-                outData[cam_id]["mc_core_x"] = event.mc.core_x.to("m").value
-                outData[cam_id]["mc_core_y"] = event.mc.core_y.to("m").value
+                outData[cam_id]["mc_core_x"] = event.simulation.shower.core_x.to("m").value
+                outData[cam_id]["mc_core_y"] = event.simulation.shower.core_y.to("m").value
                 outData[cam_id]["reco_core_x"] = reco_core_x.to("m").value
                 outData[cam_id]["reco_core_y"] = reco_core_y.to("m").value
-                outData[cam_id]["mc_h_first_int"] = event.mc.h_first_int.to("m").value
+                outData[cam_id]["mc_h_first_int"] = event.simulation.shower.h_first_int.to("m").value
                 outData[cam_id]["offset"] = offset.to("deg").value
-                outData[cam_id]["mc_x_max"] = event.mc.x_max.value  # g / cm2
+                outData[cam_id]["mc_x_max"] = event.simulation.shower.x_max.value  # g / cm2
                 outData[cam_id]["alt"] = reco_result.alt.to("deg").value
                 outData[cam_id]["az"] = reco_result.az.to("deg").value
                 outData[cam_id]["reco_energy_tel"] = reco_energy_tel[tel_id]

--- a/protopipe/scripts/write_dl2.py
+++ b/protopipe/scripts/write_dl2.py
@@ -9,11 +9,8 @@ import tables as tb
 import astropy.units as u
 
 # ctapipe
-# from ctapipe.io import EventSourceFactory
-from ctapipe.io import event_source
+from ctapipe.io import EventSource
 from ctapipe.utils.CutFlow import CutFlow
-from ctapipe.reco.energy_regressor import EnergyRegressor
-from ctapipe.reco.event_classifier import EventClassifier
 
 # Utilities
 from protopipe.pipeline import EventPreparer
@@ -23,12 +20,11 @@ from protopipe.pipeline.utils import (
     prod3b_array,
     str2bool,
     load_config,
+    load_models,
     SignalHandler,
 )
 
-# from memory_profiler import profile
 
-# @profile
 def main():
 
     # Argument parser
@@ -148,7 +144,7 @@ def main():
                 "cam_id": "{cam_id}",
             }
         )
-        classifier = EventClassifier.load(clf_file, cam_id_list=cams_and_foclens.keys())
+        classifiers = load_models(clf_file, cam_id_list=cams_and_foclens.keys())
         if args.debug:
             print(
                 bcolors.OKBLUE
@@ -171,7 +167,7 @@ def main():
                 "cam_id": "{cam_id}",
             }
         )
-        regressor = EnergyRegressor.load(reg_file, cam_id_list=cams_and_foclens.keys())
+        regressors = load_models(reg_file, cam_id_list=cams_and_foclens.keys())
         if args.debug:
             print(
                 bcolors.OKBLUE
@@ -186,11 +182,12 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
 
     # Declaration of the column descriptor for the (possible) images file
-    class StoredImages(tb.IsDescription):
-        event_id = tb.Int32Col(dflt=1, pos=0)
+    StoredImages = dict(
+        event_id = tb.Int32Col(dflt=1, pos=0),
         tel_id = tb.Int16Col(dflt=1, pos=1)
-        dl1_phe_image = tb.Float32Col(shape=(1855), pos=2)
-        mc_phe_image = tb.Float32Col(shape=(1855), pos=3)
+        # reco_image, true_image and cleaning_mask_reco
+        # are defined later sicne they depend on the number of pixels
+        )
 
     # this class defines the reconstruction parameters to keep track of
     class RecoEvent(tb.IsDescription):
@@ -249,7 +246,7 @@ def main():
 
     for i, filename in enumerate(filenamelist):
 
-        source = event_source(
+        source = EventSource(
             input_url=filename, allowed_tels=allowed_tels, max_events=args.max_events
         )
         # loop that cleans and parametrises the images and performs the reconstruction
@@ -275,15 +272,15 @@ def main():
         ):
 
             # True energy
-            true_energy = event.mc.energy.value
+            true_energy = event.simulation.shower.energy.value
             
             # True direction
-            true_az = event.mc.az
-            true_alt = event.mc.alt
+            true_az = event.simulation.shower.az
+            true_alt = event.simulation.shower.alt
             
-            # Angular quantities
-            run_array_direction = event.mcheader.run_array_direction
-            pointing_az, pointing_alt = run_array_direction[0], run_array_direction[1]
+            # Array pointing in AltAz frame
+            pointing_az = event.pointing.array_azimuth
+            pointing_alt = event.pointing.array_altitude
 
             if good_event:  # aka it has been successfully reconstructed
 
@@ -291,7 +288,7 @@ def main():
                 # - true direction
                 # - reconstruted direction
                 xi = angular_separation(
-                    event.mc.az, event.mc.alt, reco_result.az, reco_result.alt
+                    event.simulation.shower.az, event.simulation.shower.alt, reco_result.az, reco_result.alt
                 )
 
                 # Angular separation between
@@ -342,7 +339,7 @@ def main():
 
                     cam_id = source.subarray.tel[tel_id].camera.camera_name
                     moments = hillas_dict[tel_id]
-                    model = regressor.model_dict[cam_id]
+                    model = regressors[cam_id]
 
                     # Features to be fed in the regressor
                     features_img = np.array(
@@ -394,7 +391,7 @@ def main():
                 for idx, tel_id in enumerate(hillas_dict.keys()):
                     cam_id = source.subarray.tel[tel_id].camera.camera_name
                     moments = hillas_dict[tel_id]
-                    model = classifier.model_dict[cam_id]
+                    model = classifiers[cam_id]
                     # Features to be fed in the classifier
                     # this should be read in some way from
                     # the classifier configuration file!!!!!
@@ -482,28 +479,43 @@ def main():
             # If the user wants to save the images of the run
             if args.save_images is True:
                 for idx, tel_id in enumerate(hillas_dict.keys()):
-                    cam_id = event.inst.subarray.tel[tel_id].camera.cam_id
+                    cam_id = source.subarray.tel[tel_id].camera.camera_name
                     if cam_id not in images_phe:
+                        
+                        n_pixels = source.subarray.tel[tel_id].camera.geometry.n_pixels
+                        StoredImages["true_image"] = tb.Float32Col(
+                            shape=(n_pixels), pos=2
+                        )
+                        StoredImages["reco_image"] = tb.Float32Col(
+                            shape=(n_pixels), pos=3
+                        )
+                        StoredImages["cleaning_mask_reco"] = tb.BoolCol(
+                            shape=(n_pixels), pos=4
+                        )  # not in ctapipe
+                        StoredImages["cleaning_mask_clusters"] = tb.BoolCol(
+                            shape=(n_pixels), pos=5
+                        )  # not in ctapipe
+                        
                         images_table[cam_id] = images_outfile.create_table(
                             "/", "_".join(["images", cam_id]), StoredImages
                         )
-                        images_phe[cam_id] = images_table[cam_id].row
+                    images_phe[cam_id] = images_table[cam_id].row
 
-                images_phe[cam_id]["event_id"] = event.r0.event_id
-                images_phe[cam_id]["tel_id"] = tel_id
-                images_phe[cam_id]["reco_image"] = reco_image[tel_id]
-                images_phe[cam_id]["true_image"] = true_image[tel_id]
-                images_phe[cam_id]["cleaning_mask_reco"] = cleaning_mask_reco[tel_id]
-                images_phe[cam_id]["cleaning_mask_clusters"] = cleaning_mask_clusters[
-                    tel_id
-                ]
+                    images_phe[cam_id]["event_id"] = event.index.event_id
+                    images_phe[cam_id]["tel_id"] = tel_id
+                    images_phe[cam_id]["reco_image"] = reco_image[tel_id]
+                    images_phe[cam_id]["true_image"] = true_image[tel_id]
+                    images_phe[cam_id]["cleaning_mask_reco"] = cleaning_mask_reco[tel_id]
+                    images_phe[cam_id]["cleaning_mask_clusters"] = cleaning_mask_clusters[
+                        tel_id
+                    ]
 
-                images_phe[cam_id].append()
+                    images_phe[cam_id].append()
 
             # Now we start recording the data to file
             reco_event["event_id"] = event.index.event_id
             reco_event["obs_id"] = event.index.obs_id
-            reco_event["NTels_trig"] = len(event.dl0.tels_with_data)
+            reco_event["NTels_trig"] = len(event.r1.tel.keys())
             reco_event["NTels_reco"] = len(hillas_dict)
             reco_event["NTels_reco_lst"] = n_tels["LST_LST_LSTCam"]
             reco_event["NTels_reco_mst"] = (
@@ -536,10 +548,10 @@ def main():
             reco_event["ErrEstDir"] = np.nan
 
             # Simulated information
-            shower = event.mc
+            shower = event.simulation.shower
             mc_core_x = shower.core_x
             mc_core_y = shower.core_y
-            reco_event["true_energy"] = event.mc.energy.to("TeV").value
+            reco_event["true_energy"] = shower.energy.to("TeV").value
             reco_event["true_az"] = true_az.to("deg").value
             reco_event["true_alt"] = true_alt.to("deg").value
             reco_event["true_core_x"] = mc_core_x.to("m").value
@@ -561,7 +573,6 @@ def main():
         for table in images_table.values():
             table.flush()
 
-    # Add in meta-data's table?
     try:
         print()
         evt_cutflow()

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ extras_require = {
         "gammapy",
         "pytest",
         "numpy",
-        "ctapipe==0.9.1",
+        "ctapipe==0.10.5",
         "pyirf",
     ],
     "tests": [
         "pytest",
         "pytest-cov",
+        "pytest-dependency",
         "codecov",
-        "ctapipe-extra @ https://github.com/cta-observatory/ctapipe-extra/archive/v0.3.1.tar.gz",
     ],
 }
 
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(),
     package_data={"protopipe": ["aux/example_config_files/analysis.yaml"]},
     include_package_data=True,
-    install_requires=["ctapipe==0.9.1", "pyirf"],
+    install_requires=["ctapipe==0.10.5", "pyirf"],
     zip_safe=False,
     use_scm_version={"write_to": os.path.join("protopipe", "_version.py")},
     tests_require=extras_require["tests"],


### PR DESCRIPTION
This PR is a requirement for PR #110, which started in the same way, but I preferred to split API upgrade from the refactoring based on `ctapipe.core.Tool`s.

Now all ctapipe-related API is based on ctapipe 0.10.5.

I also introduced a new conda environment file for released versions.