### PR TITLE
Add pandas to pip installation

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
-echo "Using conda"
-source $CONDA/etc/profile.d/conda.sh
-conda config --set always_yes yes --set changeps1 no
-conda update -q conda  # get latest conda version
-# Useful for debugging any issues with conda
-conda info -a
+if [[ "$INSTALL_METHOD" == "conda" ]]; then
+  echo "Using conda"
+  source $CONDA/etc/profile.d/conda.sh
+  conda config --set always_yes yes --set changeps1 no
+  conda update -q conda  # get latest conda version
+  # Useful for debugging any issues with conda
+  conda info -a
 
-sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment_development.yml
-conda install -c conda-forge mamba
-mamba env create -n protopipe --file environment_development.yml
-conda activate protopipe
+  sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment_development.yml
+  conda install -c conda-forge mamba
+  mamba env create -n protopipe --file environment_development.yml
+  conda activate protopipe
+else
+  echo "Using pip"
+  pip install -U pip setuptools wheel
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        install-method: ["conda"]
+        install-method: ["pip", "conda"]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,9 +38,11 @@ jobs:
         env:
           INSTALL_METHOD: ${{ matrix.install-method }}
         run: |
-          source $CONDA/etc/profile.d/conda.sh
-          conda activate protopipe
-          conda list
+          if [[ "$INSTALL_METHOD" == "conda" ]]; then
+            source $CONDA/etc/profile.d/conda.sh
+            conda activate protopipe
+            conda list
+          fi
           ctapipe-info --version
           pytest --cov=protopipe --cov-report=xml
       - uses: codecov/codecov-action@v1
@@ -58,7 +60,9 @@ jobs:
           pre-build-command: |
             apt update --yes && apt install --yes git build-essential pandoc
             pip install -U pip setuptools wheel
-            pip install --use-feature=2020-resolver -e .[docs]
+            pip install -e .[docs]
+          # treat warnings as errors, make sure links are working
+          build-command: make html SPHINXOPTS="-W --keep-going -n --color -w /tmp/sphinx-log"
       - name: Deploy to github pages
         # only run on push to master
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(),
     package_data={"protopipe": ["aux/example_config_files/analysis.yaml"]},
     include_package_data=True,
-    install_requires=["ctapipe==0.11.0", "pyirf"],
+    install_requires=["ctapipe==0.11.0", "pyirf", "pandas"],
     zip_safe=False,
     use_scm_version={"write_to": os.path.join("protopipe", "_version.py")},
     tests_require=extras_require["tests"],


### PR DESCRIPTION
If installing only using pip it now required by both `protopipe-TRAINING` and `protopipe-DL2` that `pandas` is installed together with ctapipe and pyirf

TODO:

- [x] test pure pip installation in the CI and not only the one based on the conda environment file