### PR TITLE
Add support for calibscale

### DIFF
--- a/protopipe/aux/example_config_files/analysis.yaml
+++ b/protopipe/aux/example_config_files/analysis.yaml
@@ -11,6 +11,12 @@ General:
  array: full_array
  cam_id_list : ['LSTCam', 'NectarCam'] # Selected cameras (disabled option)
 
+Calibration:
+  # factor to transform the integrated charges (in ADC counts) into number of
+  # photoelectrons
+  # the pixel-wise one calculated by simtelarray is 0.92
+  calibscale: 0.92
+
 # Cleaning for reconstruction
 ImageCleaning:
 

--- a/protopipe/pipeline/event_preparer.py
+++ b/protopipe/pipeline/event_preparer.py
@@ -144,6 +144,14 @@ class EventPreparer:
         debug=False,
     ):
         """Initiliaze an EventPreparer object."""
+
+        # Calibscale
+        try:
+            self.calibscale = config["Calibration"]["calibscale"]
+        except KeyError:
+            # defaults for no calibscale applied
+            self.calibscale = 1.0
+
         # Cleaning for reconstruction
         self.cleaner_reco = ImageCleaner(  # for reconstruction
             config=config["ImageCleaning"]["biggest"],
@@ -458,7 +466,8 @@ class EventPreparer:
                 n_tels[tel_type] += 1
 
                 # use ctapipe's functionality to get the calibrated image
-                pmt_signal = event.dl1.tel[tel_id].image
+                # and scale the reconstructed values if required
+                pmt_signal = event.dl1.tel[tel_id].image / self.calibscale
 
                 # If required...
                 if save_images is True:

--- a/protopipe/scripts/tests/test_config_analysis_north.yaml
+++ b/protopipe/scripts/tests/test_config_analysis_north.yaml
@@ -11,6 +11,12 @@ General:
  array: full_array
  cam_id_list : ['LSTCam', 'NectarCam'] # Selected cameras (disabled option)
 
+Calibration:
+  # factor to transform the integrated charges (in ADC counts) into number of
+  # photoelectrons
+  # the pixel-wise one calculated by simtelarray is 0.92
+  calibscale: 0.92
+
 # Cleaning for reconstruction
 ImageCleaning:
 

--- a/protopipe/scripts/tests/test_config_analysis_south.yaml
+++ b/protopipe/scripts/tests/test_config_analysis_south.yaml
@@ -11,6 +11,12 @@ General:
  array: full_array
  cam_id_list : ['LSTCam', 'FlashCam', 'CHEC'] # Selected cameras (disabled option)
 
+Calibration:
+  # factor to transform the integrated charges (in ADC counts) into number of
+  # photoelectrons
+  # the pixel-wise one calculated by simtelarray is 0.92
+  calibscale: 0.92
+
 # Cleaning for reconstruction
 ImageCleaning:
 


### PR DESCRIPTION
This PR adds the choice of `calibscale` from the analysis configuration file setting 1.0 (i.e. no calibscale) as default and scaling the extracted image before cleaning.