### PR TITLE
Ensure that estimated energy is always recorded in linear scale

### DIFF
--- a/protopipe/aux/example_config_files/AdaBoostRegressor.yaml
+++ b/protopipe/aux/example_config_files/AdaBoostRegressor.yaml
@@ -26,6 +26,7 @@ GridSearchCV:
 Method:
   name: 'sklearn.ensemble.AdaBoostRegressor'
   target_name: 'true_energy'
+  log_10_target: True # this makes the model use log10(target_name)
   # Please, see scikit-learn's API for what each parameter means
   # NOTE: null == None
   base_estimator:

--- a/protopipe/aux/example_config_files/RandomForestRegressor.yaml
+++ b/protopipe/aux/example_config_files/RandomForestRegressor.yaml
@@ -26,7 +26,8 @@ GridSearchCV:
 # Definition of the model algorithm/method used and its hyper-parameters
 Method:
   name: 'sklearn.ensemble.RandomForestRegressor' # DO NOT CHANGE
-  target_name: 'log10_true_energy'
+  target_name: 'true_energy'
+  log_10_target: True # this makes the model use log10(target_name)
   tuned_parameters:
     # Please, see scikit-learn's API for what each parameter means
     # NOTE: null == None

--- a/protopipe/scripts/build_model.py
+++ b/protopipe/scripts/build_model.py
@@ -71,13 +71,6 @@ def main():
     train_fraction = cfg["Split"]["train_fraction"]
     # Name of target quantity
     target_name = cfg["Method"]["target_name"]
-    try:
-        log_10_target = cfg["Method"]["log_10_target"]
-    except KeyError:
-        log_10_target = True
-
-    if log_10_target:
-        target_name = f"log10_{target_name}"
 
     # Get list of features
     features_basic = cfg["FeatureList"]["Basic"]
@@ -129,6 +122,14 @@ def main():
                    "classifier": ["RandomForestClassifier"]}
 
     if class_name in model_types["regressor"]:
+
+        try:
+            log_10_target = cfg["Method"]["log_10_target"]
+        except KeyError:
+            log_10_target = True
+
+        if log_10_target:
+            target_name = f"log10_{target_name}"
 
         # Get the selection cuts
         cuts = make_cut_list(cfg["SigFiducialCuts"])

--- a/protopipe/scripts/build_model.py
+++ b/protopipe/scripts/build_model.py
@@ -71,6 +71,13 @@ def main():
     train_fraction = cfg["Split"]["train_fraction"]
     # Name of target quantity
     target_name = cfg["Method"]["target_name"]
+    try:
+        log_10_target = cfg["Method"]["log_10_target"]
+    except KeyError:
+        log_10_target = True
+
+    if log_10_target:
+        target_name = f"log_10_{target_name}"
 
     # Get list of features
     features_basic = cfg["FeatureList"]["Basic"]

--- a/protopipe/scripts/build_model.py
+++ b/protopipe/scripts/build_model.py
@@ -77,7 +77,7 @@ def main():
         log_10_target = True
 
     if log_10_target:
-        target_name = f"log_10_{target_name}"
+        target_name = f"log10_{target_name}"
 
     # Get list of features
     features_basic = cfg["FeatureList"]["Basic"]

--- a/protopipe/scripts/data_training.py
+++ b/protopipe/scripts/data_training.py
@@ -119,6 +119,7 @@ def main():
 
         # Read configuration file
         regressor_config = load_config(args.regressor_config)
+        log_10_target = regressor_config["Method"]["log_10_target"]
 
         regressor_files = (
             args.regressor_dir + "/regressor_{cam_id}_{regressor}.pkl.gz"
@@ -379,6 +380,10 @@ def main():
                         data.eval(f'estimation_weight = {estimation_weight}', inplace=True)
                         energy_tel[idx] = model.predict(features_values)
                         weight_tel[idx] = data["estimation_weight"]
+
+                    if log_10_target:
+                        energy_tel[idx] = 10**energy_tel[idx]
+                        weight_tel[idx] = 10**weight_tel[idx]
 
                     reco_energy_tel[tel_id] = energy_tel[idx]
 

--- a/protopipe/scripts/tests/test_AdaBoostRegressor.yaml
+++ b/protopipe/scripts/tests/test_AdaBoostRegressor.yaml
@@ -28,6 +28,7 @@ GridSearchCV:
 Method:
   name: 'sklearn.ensemble.AdaBoostRegressor'
   target_name: 'true_energy'
+  log_10_target: True # this makes the model use log10(target_name)
   # Please, see scikit-learn's API for what each parameter means
   # NOTE: null == None
   base_estimator:

--- a/protopipe/scripts/tests/test_RandomForestRegressor.yaml
+++ b/protopipe/scripts/tests/test_RandomForestRegressor.yaml
@@ -27,7 +27,8 @@ GridSearchCV:
 # Definition of the model algorithm/method used and its hyper-parameters
 Method:
   name: 'sklearn.ensemble.RandomForestRegressor' # DO NOT CHANGE
-  target_name: 'log10_true_energy'
+  target_name: 'true_energy'
+  log_10_target: True # this makes the model use log10(target_name)
   tuned_parameters:
     # Please, see scikit-learn's API for what each parameter means
     # NOTE: null == None

--- a/protopipe/scripts/write_dl2.py
+++ b/protopipe/scripts/write_dl2.py
@@ -183,6 +183,7 @@ def main():
 
         # Read configuration file
         regressor_config = load_config(args.regressor_config)
+        log_10_target = regressor_config["Method"]["log_10_target"]
 
         regressor_files = (
             args.regressor_dir + "/regressor_{cam_id}_{regressor}.pkl.gz"
@@ -426,6 +427,10 @@ def main():
                         weight_tel[idx] = data["estimation_weight_energy"]
                     else:
                         energy_tel[idx] = np.nan
+
+                    if log_10_target:
+                        energy_tel[idx] = 10**energy_tel[idx]
+                        weight_tel[idx] = 10**weight_tel[idx]
 
                     # Record the values regardless of the validity
                     # We don't use this now, but it should be recorded


### PR DESCRIPTION
This closes #139.

It also fixes a detail about energy estimation à-la-CTAMARS (#92), namely,

> [...] the RFs provide estimates for log10 E and its RMS, but the average is done after converting those to linear energy scale)
