### PR TITLE
Calculate impact parameter always in the tilted frame

### DIFF
--- a/protopipe/pipeline/event_preparer.py
+++ b/protopipe/pipeline/event_preparer.py
@@ -969,8 +969,8 @@ class EventPreparer:
                         tel_tilted = tel_ground.transform_to(tilted_frame)
 
                         # but this not
-                        core_tilted = SkyCoord(x=core_ground[0] * u.m,
-                                               y=core_ground[1] * u.m,
+                        core_tilted = SkyCoord(x=core_ground.x,
+                                               y=core_ground.y,
                                                frame=tilted_frame
                                                )
 

--- a/protopipe/pipeline/event_preparer.py
+++ b/protopipe/pipeline/event_preparer.py
@@ -445,7 +445,7 @@ class EventPreparer:
             # Array pointing in AltAz frame
             az = event.pointing.array_azimuth
             alt = event.pointing.array_altitude
-            array_pointing = SkyCoord(alt, az, frame=AltAz())
+            array_pointing = SkyCoord(az, alt, frame=AltAz())
 
             ground_frame = GroundFrame()
 


### PR DESCRIPTION
in this PR I basically bring the estimated core position back to the tilted frame (in which it was before being recorded by the HillasReconstructor)