### PR TITLE
Set effective area HDU name as gammapy wants

### DIFF
--- a/protopipe/perf/utils.py
+++ b/protopipe/perf/utils.py
@@ -36,7 +36,7 @@ def initialize_script_arguments():
         "--indir",
         type=str,
         default=None,
-        help="Directory containing the required DL2 input files"
+        help="Directory containing the required DL2 input files (default: read from config file)"
     )
     parser.add_argument(
         "--template_input_file",
@@ -48,18 +48,19 @@ def initialize_script_arguments():
         "--outdir_path",
         type=str,
         default=None,
-        help="Output directory for DL3 file"
+        help="Output directory for DL3 file (default: read from config file)"
     )
     parser.add_argument(
         "--out_file_name",
         type=str,
         default=None,
-        help="Desired name for DL3 file"
+        help="Desired name for DL3 file (default: built from config file)"
     )
 
     args = parser.parse_args()
 
     return args
+
 
 def percentiles(values, bin_values, bin_edges, percentile):
     # Seems complicated for vector defined as [inf, inf, .., inf]

--- a/protopipe/scripts/make_performance_EventDisplay.py
+++ b/protopipe/scripts/make_performance_EventDisplay.py
@@ -88,7 +88,8 @@ def main():
 
     outdir = os.path.join(outdir_path, out_file_name)
 
-    T_OBS = cfg['analysis']['obs_time']['value'] * u.Unit(cfg['analysis']['obs_time']['unit'])
+    T_OBS = cfg['analysis']['obs_time']['value'] * \
+        u.Unit(cfg['analysis']['obs_time']['unit'])
 
     # scaling between on and off region.
     # Make off region 5 times larger than on region for better
@@ -120,10 +121,11 @@ def main():
 
     for particle_type, p in particles.items():
         log.info(f"Simulated {particle_type.title()} Events:")
-        p["events"], p["simulation_info"] = read_DL2_pyirf(p["file"],p["run_header"])
+        p["events"], p["simulation_info"] = read_DL2_pyirf(p["file"], p["run_header"])
 
         # Multiplicity cut
-        p["events"] = p["events"][p["events"]["multiplicity"] >= cfg['analysis']['cut_on_multiplicity']].copy()
+        p["events"] = p["events"][p["events"]["multiplicity"]
+                                  >= cfg['analysis']['cut_on_multiplicity']].copy()
 
         p["simulated_spectrum"] = PowerLaw.from_simulation(p["simulation_info"], T_OBS)
         # Weight events
@@ -163,10 +165,9 @@ def main():
 
     # event display uses much finer bins for the theta cut than
     # for the sensitivity
-    theta_bins = add_overflow_bins(
-        create_bins_per_decade(10 ** (-1.9) * u.TeV, 10 ** 2.3005 * u.TeV, 50,)
-    )
-
+    theta_bins = add_overflow_bins(create_bins_per_decade(10 ** (-1.9) * u.TeV,
+                                                          10 ** 2.31 * u.TeV,
+                                                          50))
     # theta cut is 68 percent containmente of the gammas
     # for now with a fixed global, unoptimized score cut
     mask_theta_cuts = gammas["gh_score"] >= INITIAL_GH_CUT
@@ -181,11 +182,9 @@ def main():
     )
 
     # same bins as event display uses
-    sensitivity_bins = add_overflow_bins(
-        create_bins_per_decade(
-            10 ** -1.9 * u.TeV, 10 ** 2.31 * u.TeV, bins_per_decade=5
-        )
-    )
+    sensitivity_bins = add_overflow_bins(create_bins_per_decade(10 ** -1.9 * u.TeV,
+                                                                10 ** 2.31 * u.TeV,
+                                                                bins_per_decade=5))
 
     log.info("Optimizing G/H separation cut for best sensitivity")
     gh_cut_efficiencies = np.arange(
@@ -267,15 +266,12 @@ def main():
     }
 
     # binnings for the irfs
-    true_energy_bins = add_overflow_bins(
-        create_bins_per_decade(10 ** -1.9 * u.TeV, 10 ** 2.31 * u.TeV, 10)
-    )
-    reco_energy_bins = add_overflow_bins(
-        create_bins_per_decade(10 ** -1.9 * u.TeV, 10 ** 2.31 * u.TeV, 5)
-    )
+    true_energy_bins = create_bins_per_decade(10 ** -1.9 * u.TeV, 10 ** 2.31 * u.TeV, 10)
+    reco_energy_bins = create_bins_per_decade(10 ** -1.9 * u.TeV, 10 ** 2.31 * u.TeV, 5)
+
     fov_offset_bins = [0, 0.5] * u.deg
     source_offset_bins = np.arange(0, 1 + 1e-4, 1e-3) * u.deg
-    energy_migration_bins = np.geomspace(0.2, 5, 200)
+    energy_migration_bins = np.arange(0, 5, 0.01)
 
     for label, mask in masks.items():
         effective_area = effective_area_per_energy(
@@ -313,7 +309,7 @@ def main():
         gammas[gammas["selected"]],
         reco_energy_bins,
         energy_type="reco"
-        )
+    )
 
     # Here we use reconstructed energy instead of true energy for the sake of
     # current pipelines comparisons
@@ -321,7 +317,7 @@ def main():
         gammas[gammas["selected_gh"]],
         reco_energy_bins,
         energy_type="reco"
-        )
+    )
 
     psf = psf_table(
         gammas[gammas["selected_gh"]],

--- a/protopipe/scripts/make_performance_EventDisplay.py
+++ b/protopipe/scripts/make_performance_EventDisplay.py
@@ -288,7 +288,7 @@ def main():
                 effective_area[..., np.newaxis],  # +1 dimension for FOV offset
                 true_energy_bins,
                 fov_offset_bins,
-                extname="EFFECTIVE_AREA" + label,
+                extname="EFFECTIVE AREA" + label,
             )
         )
         edisp = energy_dispersion(


### PR DESCRIPTION
Closes #142 

it also takes care of few other things:
- removes under/over-flow bins when recording IRFs (this was also making gammapy crash)
- fixes energy migration bins in the energy dispersion IRF
- improves the CLI help of the command and some automatic formatting compliant with PEP8