### PR TITLE
Fix CALIB_SCALE key in analysis.yaml

### DIFF
--- a/protopipe/aux/example_config_files/analysis.yaml
+++ b/protopipe/aux/example_config_files/analysis.yaml
@@ -16,7 +16,7 @@ Calibration:
   # factor to transform the integrated charges (in ADC counts) into number of
   # photoelectrons
   # the pixel-wise one calculated by simtelarray is 0.92
-  calibscale: 0.92
+  calib_scale: 0.92
   apply_integration_correction: false
 
 # Cleaning for reconstruction


### PR DESCRIPTION
Fix a typo in the example config file of the analysis which would disable CALIB_SCALE if not fixed by the user