### PR TITLE
Make progress bar optional and add it also to DL2 script

### DIFF
--- a/protopipe/scripts/data_training.py
+++ b/protopipe/scripts/data_training.py
@@ -34,6 +34,12 @@ def main():
     parser.add_argument(
         "--debug", action="store_true", help="Print debugging information",
     )
+    
+    parser.add_argument(
+        "--show_progress_bar",
+        action="store_true",
+        help="Show information about execution progress",
+    )
 
     parser.add_argument(
         "--save_images", action="store_true", help="Save also all images",
@@ -269,7 +275,8 @@ def main():
                                          debug=args.debug),
                     desc=source.__class__.__name__,
                     total=source.max_events,
-                    unit="event"
+                    unit="event",
+                    disable= not args.show_progress_bar
                  ):
 
             if good_event:

--- a/protopipe/scripts/write_dl2.py
+++ b/protopipe/scripts/write_dl2.py
@@ -35,6 +35,12 @@ def main():
     parser.add_argument(
         "--debug", action="store_true", help="Print debugging information",
     )
+    
+    parser.add_argument(
+        "--show_progress_bar",
+        action="store_true",
+        help="Show information about execution progress",
+    )
 
     parser.add_argument("--regressor_dir", default="./", help="regressors directory")
     parser.add_argument("--classifier_dir", default="./", help="regressors directory")
@@ -314,7 +320,8 @@ def main():
                                          debug=args.debug),
                     desc=source.__class__.__name__,
                     total=source.max_events,
-                    unit="event"
+                    unit="event",
+                    disable= not args.show_progress_bar
                  ):
 
             # True direction


### PR DESCRIPTION
In the case of a finite number of shower events, the GRID was killing the jobs due to the ASCII characters of the progress bar.