### PR TITLE
Point switcher JSON to its version on latest readthedocs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ html_theme = "pydata_sphinx_theme"
 
 # VERSIONING
 # Define the json_url for our version switcher.
-json_url = "https://github.com/cta-observatory/protopipe/tree/master/docs/_static/switcher.json"
+json_url = "https://protopipe.readthedocs.io/en/latest/_static/switcher.json"
 
 # Define the version we use for matching in the version switcher.
 version_match = os.environ.get("READTHEDOCS_VERSION")

--- a/environment_development.yml
+++ b/environment_development.yml
@@ -23,6 +23,7 @@ dependencies:
   - sphinx-automodapi
   - numpydoc
   - sphinx-issues
+  - sphinx-panels
   # Benchmarking
   - papermill
   - jupyterlab>=3.1.10

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ extras_require = {
         "jinja2==3.0.3",
         "pydata-sphinx-theme~=0.8",
         "sphinx-issues",
+        "sphinx-panels"
         "sphinx_automodapi",
         "numpydoc",
         "ipython",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
         "jinja2==3.0.3",
         "pydata-sphinx-theme~=0.8",
         "sphinx-issues",
-        "sphinx-panels"
+        "sphinx-panels",
         "sphinx_automodapi",
         "numpydoc",
         "ipython",


### PR DESCRIPTION
Hopefully, this closes #195.

The reason behind the malfunction might be a CORS (Cross-Origin Resource Sharing) issue: basically an issue in sharing URLs access between different APIs (in our case GitHub and readthedocs).
During the build on readthedocs (in our case) it should be more safe to stay "there" when looking for reference files at specific URLs.

The documentation build from the CI should work anyways as it doesn't use the latest JSON file (the PR has a more predictable reference).